### PR TITLE
issue-64 add mac support annotation

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/collate_html_reports.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_html_reports.rb
@@ -221,7 +221,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
 
       def self.category

--- a/lib/fastlane/plugin/test_center/actions/collate_json_reports.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_json_reports.rb
@@ -161,7 +161,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
 
       def self.category

--- a/lib/fastlane/plugin/test_center/actions/collate_junit_reports.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_junit_reports.rb
@@ -148,7 +148,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
@@ -177,7 +177,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -316,7 +316,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/test_center/actions/suppress_tests.rb
+++ b/lib/fastlane/plugin/test_center/actions/suppress_tests.rb
@@ -169,7 +169,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/test_center/actions/suppress_tests_from_junit.rb
+++ b/lib/fastlane/plugin/test_center/actions/suppress_tests_from_junit.rb
@@ -133,7 +133,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/test_center/actions/suppressed_tests.rb
+++ b/lib/fastlane/plugin/test_center/actions/suppressed_tests.rb
@@ -137,7 +137,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/test_center/actions/tests_from_junit.rb
+++ b/lib/fastlane/plugin/test_center/actions/tests_from_junit.rb
@@ -80,7 +80,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
     end
   end

--- a/lib/fastlane/plugin/test_center/actions/tests_from_xctestrun.rb
+++ b/lib/fastlane/plugin/test_center/actions/tests_from_xctestrun.rb
@@ -90,7 +90,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        platform == :ios
+        %i[ios mac].include?(platform)
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

The actions all should work with Xcode related artifacts. They all declared that they only work for the iOS platform, but not the Mac platform. This change fixes that [Issue 64](https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/issues/64).

### Description
<!-- Describe your changes in detail -->

Added `:mac` as another supported platform.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md