### PR TITLE
issue-74 find xcode swift 4 tests

### DIFF
--- a/fastlane-plugin-test_center.gemspec
+++ b/fastlane-plugin-test_center.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json'
   spec.add_dependency 'plist'
   spec.add_dependency 'xcodeproj'
-  spec.add_dependency 'xctest_list', '>= 1.1.4'
+  spec.add_dependency 'xctest_list', '>= 1.1.6'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'colorize'


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

Fixes #74 

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

As of Xcode 10, the `xctest_list` gem was unable to find Swift tests. That gem has been updated and _requiring_ that fixed version or later allows `multi_scan` to find the tests.

### Description
<!-- Describe your changes in detail -->

See above

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md