### PR TITLE
fix issue-77 new __xctestrun_metadata__ entry in testables

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/tests_from_xctestrun.rb
+++ b/lib/fastlane/plugin/test_center/actions/tests_from_xctestrun.rb
@@ -12,6 +12,8 @@ module Fastlane
         xctestrun_rootpath = File.dirname(xctestrun_path)
         tests = Hash.new([])
         xctestrun.each do |testable_name, xctestrun_config|
+          next if testable_name == '__xctestrun_metadata__'
+
           test_identifiers = XCTestList.tests(xctest_bundle_path(xctestrun_rootpath, xctestrun_config))
           if xctestrun_config.key?('SkipTestIdentifiers')
             test_identifiers.reject! { |test_identifier| xctestrun_config['SkipTestIdentifiers'].include?(test_identifier) }

--- a/spec/fixtures/fake.xctestrun
+++ b/spec/fixtures/fake.xctestrun
@@ -149,5 +149,27 @@
 		<key>UserAttachmentLifetime</key>
 		<string>deleteOnSuccess</string>
 	</dict>
+	<key>__xctestrun_metadata__</key>
+	<dict>
+		<key>CodeCoverageBuildableInfos</key>
+		<array>
+			<dict>
+				<key>Architecture</key>
+				<string>x86_64</string>
+				<key>BuildableIdentifier</key>
+				<string>84CA5F5715235131003456ED:primary</string>
+				<key>Name</key>
+				<string>Innovative.app</string>
+				<key>ProductPath</key>
+				<string>__TESTROOT__/Debug-iphonesimulator/AtomicBoy.app/AtomicBoy</string>
+				<key>Toolchains</key>
+				<array>
+					<string>com.apple.dt.toolchain.XcodeDefault</string>
+				</array>
+			</dict>
+		</array>
+		<key>FormatVersion</key>
+		<integer>1</integer>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Resolves an issue where a new entry in the `xctestrun` file is not an actual testable, but metadata. When `tests_from_xctestrun` encounters this entry, it breaks.

### Description
<!-- Describe your changes in detail -->

Skip the block if the key is `__xctestrun_metadata__`. Update the `xctestrun` fixture to include this new entry.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md