### PR TITLE
Issue-79 multi_scan fails for xcodebuild server death

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -18,9 +18,9 @@ about: If something isn't working as expected 🤔
 <!-- Please include what's happening, expected behavior, and any relevant code samples -->
 
 ##### Complete output when running fastlane, including the stack trace and command used
-<!-- You can use: `--capture_output` as the last commandline argument to get that collected for you -->
+<!-- You can use: `--verbose --capture_output` as the last commandline arguments to get that collected for you -->
 
-<!-- The output of `--capture_output` could contain sensitive data such as application ids, certificate ids, passwords, authentication tokens, or email addreses, Please make sure you double check the output and replace anything sensitive you don't wish to submit in the issue -->
+<!-- The output of `--verbose --capture_output` could contain sensitive data such as application ids, certificate ids, passwords, authentication tokens, or email addreses, Please make sure you double check the output and replace anything sensitive you don't wish to submit in the issue -->
 
 <details>
   <pre>[INSERT OUTPUT HERE]</pre>
@@ -29,7 +29,7 @@ about: If something isn't working as expected 🤔
 ### Environment
 
 <!-- Please run `fastlane env` and copy the output below. This will help us help you :+1:
-If you used `--capture_output` option, please remove this block as it is already included there. -->
+If you used the `--capture_output` option, please remove this block as it is already included there. -->
 
 <details>
   <pre>[INSERT OUTPUT HERE]</pre>

--- a/.github/ISSUE_TEMPLATE/REGRESSION.md
+++ b/.github/ISSUE_TEMPLATE/REGRESSION.md
@@ -25,9 +25,9 @@ about: If a recent release broke a feature 😬 (Please make sure you know the l
 <!-- Please include what's happening, expected behavior, and any relevant code samples -->
 
 ##### Complete output when running fastlane, including the stack trace and command used
-<!-- You can use: `--capture_output` as the last commandline argument to get that collected for you -->
+<!-- You can use: `--verbose --capture_output` as the last commandline arguments to get that collected for you -->
 
-<!-- The output of `--capture_output` could contain sensitive data such as application ids, certificate ids, or email addreses, Please make sure you double check the output and replace anything sensitive you don't wish to submit in the issue -->
+<!-- The output of `--verbose --capture_output` could contain sensitive data such as application ids, certificate ids, or email addreses, Please make sure you double check the output and replace anything sensitive you don't wish to submit in the issue -->
 
 <details>
   <pre>[INSERT OUTPUT HERE]</pre>
@@ -36,7 +36,7 @@ about: If a recent release broke a feature 😬 (Please make sure you know the l
 ### Environment
 
 <!-- Please run `fastlane env` and copy the output below. This will help us help you :+1:
-If you used `--capture_output` option, please remove this block as it is already included there. -->
+If you used the `--capture_output` option, please remove this block as it is already included there. -->
 
 <details>
   <pre>[INSERT OUTPUT HERE]</pre>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,4 @@
 require_relative 'test_center_utils'
-require 'pry-byebug'
 
 # Retrieves the example code from each action and runs it to ensure that everything
 # is working as intended.

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -21,15 +21,15 @@ module Fastlane
         end
         smart_scanner = ::TestCenter::Helper::CorrectingScanHelper.new(params.values)
         tests_passed = smart_scanner.scan
-        if params[:fail_build] && !tests_passed
-          raise UI.test_failure!('Tests have failed')
-        end
         summary = run_summary(params, tests_passed, smart_scanner.retry_total_count)
         unless Helper.test?
           FastlaneCore::PrintTable.print_values(
             config: summary,
             title: "multi_scan results"
           )
+        end
+        if params[:fail_build] && !tests_passed
+          raise UI.test_failure!('Tests have failed')
         end
         summary
       end

--- a/spec/collate_junit_reports_spec.rb
+++ b/spec/collate_junit_reports_spec.rb
@@ -8,11 +8,17 @@ junit_report_1 = "<?xml version='1.0' encoding='UTF-8'?>" \
 "</testsuites>"
 
 junit_report_2 = "<?xml version='1.0' encoding='UTF-8'?>" \
-"<testsuites name='AtomicBoyUITests.xctest' tests='2' failures='1'>" \
+"<testsuites name='AtomicBoyUITests.xctest' tests='3' failures='2'>" \
 "  <testsuite name='AtomicBoyUITests' tests='2' failures='1'>" \
 "    <testcase classname='AtomicBoyUITests' name='testExample' time='4.397'/>" \
 "    <testcase classname='AtomicBoyUITests' name='testExample2'>" \
 "      <failure message='((false) is true) failed'>AtomicBoyUITests.m:48</failure>" \
+"    </testcase>" \
+"    <testcase classname='AtomicBoyUITests' name='testExample2'>" \
+"      <failure message='All the grass is not green'>AtomicBoyUITests.m:987</failure>" \
+"    </testcase>" \
+"    <testcase classname='AtomicBoyUITests' name='testExample2'>" \
+"      <failure message='All that glitters is not gold'>AtomicBoyUITests.m:infinity</failure>" \
 "    </testcase>" \
 "  </testsuite>" \
 "</testsuites>"
@@ -149,19 +155,19 @@ describe Fastlane::Actions::CollateJunitReportsAction do
         )
       end"
 
-      allow(File).to receive(:exist?).with('path/to/fake_junit_report_1.xml').and_return(true)
-      allow(File).to receive(:new).with('path/to/fake_junit_report_1.xml').and_return(issue_70_report)
-      allow(File).to receive(:exist?).with('path/to/fake_junit_report_2.xml').and_return(true)
-      allow(File).to receive(:new).with('path/to/fake_junit_report_2.xml').and_return(issue_70_report_2)
-      allow(FileUtils).to receive(:mkdir_p)
+    allow(File).to receive(:exist?).with('path/to/fake_junit_report_1.xml').and_return(true)
+    allow(File).to receive(:new).with('path/to/fake_junit_report_1.xml').and_return(issue_70_report)
+    allow(File).to receive(:exist?).with('path/to/fake_junit_report_2.xml').and_return(true)
+    allow(File).to receive(:new).with('path/to/fake_junit_report_2.xml').and_return(issue_70_report_2)
+    allow(FileUtils).to receive(:mkdir_p)
 
-      report_file = StringIO.new
-      expect(File).to receive(:open).with('path/to/report.xml', 'w').and_yield(report_file)
-      Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
-      report = REXML::Document.new(report_file.string)
+    report_file = StringIO.new
+    expect(File).to receive(:open).with('path/to/report.xml', 'w').and_yield(report_file)
+    Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
+    report = REXML::Document.new(report_file.string)
 
-      testable = REXML::XPath.first(report, "//testsuites")
-      expect(testable.attributes['failures']).to eq('0')
-      expect(testable.attributes['tests']).to eq('173')
+    testable = REXML::XPath.first(report, "//testsuites")
+    expect(testable.attributes['failures']).to eq('0')
+    expect(testable.attributes['tests']).to eq('173')
   end
 end

--- a/spec/collate_test_result_bundles_spec.rb
+++ b/spec/collate_test_result_bundles_spec.rb
@@ -60,7 +60,7 @@ describe Fastlane::Actions::CollateTestResultBundlesAction do
       allow(Plist).to receive(:parse_xml).with('path/to/fake2.test_bundle/Info.plist').and_return(info_plist_2)
       expect(Plist::Emit).to receive(:save_plist).with(info_plist_1, '/tmp/path/to/fake.test_bundle/Info.plist')
       Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
-      expect(info_plist_1['Actions'][0]['EndedTime']).to eq(DateTime.parse('2018-06-25T13:32:11Z'))
+      expect(info_plist_1['Actions'][0]['EndedTime']).to eq(DateTime.parse('2018-06-25T13:32:11Z')) # rubocop:disable Style/DateTime
       expect(info_plist_1['Actions'][0]['ActionResult']['TestsFailedCount']).to eq(3)
     end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes issue-79: when Xcode has been configured to continue running a test after a failure, it generates a new test entry in the junit file. The collation of units was unable to handle duplicate entries for the same test case.

### Description
<!-- Describe your changes in detail -->

Moves all failure entries for testcase entries that are the same, but with different failures, into one testcase and remove the redundant ones. If the testcase passes later, the collation will remove the entire single element. 

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md