### PR TITLE
Issue-43 retrycount passrate in junit

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,3 +9,18 @@ lane :run_examples do
     # rubocop:enable Security/Eval
   end
 end
+
+lane :issue_43 do
+  UI.important(
+    'example: ' \
+    'multi_scan also works with just one test target in the Scheme.'
+  )
+  multi_scan(
+    project: File.absolute_path('../AtomicBoy/AtomicBoy.xcodeproj'),
+    scheme: 'Professor',
+    try_count: 3,
+    output_files: 'atomic_report.xml',
+    output_types: 'junit',
+    fail_build: false
+  )
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This change adds analytical data to the Junit report to indicate how many times a test was "retried" and how many times the entire test-run was "retried". 

### Description
<!-- Describe your changes in detail -->

Update the `collate_junit_reports` action to update a "retries" attribute to the number of other test reports that were run and update each test "retries" attribute to the number of times that the test was sent back to `xcodebuild test`.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md