### PR TITLE
issue-86 address issue when enable-testability is turned off

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/tests_from_xctestrun.rb
+++ b/lib/fastlane/plugin/test_center/actions/tests_from_xctestrun.rb
@@ -15,12 +15,17 @@ module Fastlane
         xctestrun.each do |testable_name, xctestrun_config|
           next if testable_name == '__xctestrun_metadata__'
 
-          test_identifiers = XCTestList.tests(xctest_bundle_path(xctestrun_rootpath, xctestrun_config))
+          xctest_path = xctest_bundle_path(xctestrun_rootpath, xctestrun_config)
+          test_identifiers = XCTestList.tests(xctest_path)
           UI.verbose("Found the following tests: #{test_identifiers.join("\n\t")}")
           if xctestrun_config.key?('SkipTestIdentifiers')
             skipped_tests = xctestrun_config['SkipTestIdentifiers']
             UI.verbose("Removing skipped tests: #{skipped_tests.join("\n\t")}")
             test_identifiers.reject! { |test_identifier| skipped_tests.include?(test_identifier) }
+          end
+          if test_identifiers.empty?
+            UI.error("No tests found in '#{xctest_path}'!")
+            UI.important("Is the Build Setting, `ENABLE_TESTABILITY` enabled for the test target #{testable_name}?")
           end
           tests[testable_name] = test_identifiers.map do |test_identifier|
             "#{testable_name.shellescape}/#{test_identifier}"

--- a/spec/tests_from_xctestrun_spec.rb
+++ b/spec/tests_from_xctestrun_spec.rb
@@ -59,4 +59,27 @@ describe Fastlane::Actions::TestsFromXctestrunAction do
       ]
     )
   end
+
+  it 'displays an error if no tests found in a xctestrun' do
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with('path/to/fake.xctestrun').and_return(true)
+    allow(File).to receive(:read).with('path/to/fake.xctestrun').and_return(File.read('./spec/fixtures/fake.xctestrun'))
+    allow(XCTestList)
+      .to receive(:tests)
+      .with('path/to/Debug-iphonesimulator/AtomicBoy.app/PlugIns/AtomicBoyTests.xctest')
+      .and_return([])
+    allow(XCTestList)
+      .to receive(:tests)
+      .with('path/to/Debug-iphonesimulator/AtomicBoyUITests-Runner.app/PlugIns/AtomicBoyUITests.xctest')
+      .and_return([])
+    fastfile = "lane :test do
+      tests_from_xctestrun(
+        xctestrun: 'path/to/fake.xctestrun'
+      )
+    end"
+    expect(FastlaneCore::UI).to receive(:error).with(/^No tests found.*/).twice
+    expect(FastlaneCore::UI).to receive(:important).with(/^Is the Build Setting, `ENABLE_TESTABILITY` enabled.*/).twice
+    tests = Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
+    expect(tests).to eq({'AtomicBoyTests' => [], 'AtomicBoyUITests' => [] })
+  end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

Strongly warn when no tests found in a test target and suggest that `ENABLE_TESTABILITY` be turned on.
 
### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Developers found that `multi_scan` could not run if the `ENABLE_TESTABILITY` setting was disabled because no tests were found. This prevented their tests from running.

### Description
<!-- Describe your changes in detail -->

This change adds a warning and a suggestion to turn that on in the Project.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md