### PR TITLE
Add the new quit_simulators parameter

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -10,7 +10,7 @@ module Fastlane
       def self.run(params)
         unless Helper.test?
           FastlaneCore::PrintTable.print_values(
-            config: params._values.select { |k, _| %i[try_count batch_count fail_build].include?(k) },
+            config: params._values.select { |k, _| %i[try_count batch_count fail_build quit_simulators].include?(k) },
             title: "Summary for multi_scan (test_center v#{Fastlane::TestCenter::VERSION})"
           )
         end
@@ -84,6 +84,7 @@ module Fastlane
         options_to_remove = %i[
           try_count
           batch_count
+          quit_simulators
           testrun_completed_block
           test_without_building
           output_types
@@ -154,6 +155,15 @@ module Fastlane
             verify_block: proc do |count|
               UI.user_error!("Error: Batch counts must be greater than zero") unless count > 0
             end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :quit_simulators,
+            env_name: "FL_MULTI_SCAN_QUIT_SIMULATORS",
+            description: "If the simulators need to be killed before run the tests",
+            type: Boolean,
+            is_string: false,
+            default_value: true,
+            optional: true
           ),
           FastlaneCore::ConfigItem.new(
             key: :output_types,

--- a/lib/fastlane/plugin/test_center/helper/correcting_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/correcting_scan_helper.rb
@@ -10,6 +10,7 @@ module TestCenter
         @batch_count = multi_scan_options[:batch_count] || 1
         @output_directory = multi_scan_options[:output_directory] || 'test_results'
         @try_count = multi_scan_options[:try_count]
+        @quit_simulators = multi_scan_options[:quit_simulators]
         @retry_total_count = 0
         @testrun_completed_block = multi_scan_options[:testrun_completed_block]
         @given_custom_report_file_name = multi_scan_options[:custom_report_file_name]
@@ -23,6 +24,7 @@ module TestCenter
             clean
             try_count
             batch_count
+            quit_simulators
             custom_report_file_name
             fail_build
             testrun_completed_block
@@ -276,6 +278,8 @@ module TestCenter
       end
 
       def quit_simulators
+        return unless @quit_simulators
+
         Fastlane::Actions.sh("killall -9 'iPhone Simulator' 'Simulator' 'SimulatorBridge' &> /dev/null || true", log: false)
         launchctl_list_count = 0
         while Fastlane::Actions.sh('launchctl list | grep com.apple.CoreSimulator.CoreSimulatorService || true', log: false) != ''

--- a/spec/correcting_scan_helper_spec.rb
+++ b/spec/correcting_scan_helper_spec.rb
@@ -658,7 +658,7 @@ describe TestCenter do
               expect(result).to eq(false)
             end
 
-            it 'calls scan three times when two runs have failures without kill the simulator' do
+            it 'calls scan three times when two runs have failures without killing the simulator' do
               scanner = CorrectingScanHelper.new(
                 xctestrun: 'path/to/fake.xctestrun',
                 output_directory: '.',

--- a/spec/correcting_scan_helper_spec.rb
+++ b/spec/correcting_scan_helper_spec.rb
@@ -691,7 +691,7 @@ describe TestCenter do
                 raise FastlaneCore::Interface::FastlaneTestFailure, 'failed tests'
               end
 
-              expect(Fastlane::Actions).not_to receive(:sh)
+              expect(Fastlane::Actions).not_to receive(:sh).with(/killall -9 'iPhone Simulator' 'Simulator' 'SimulatorBridge'.*/, anything)
               result = scanner.correcting_scan(
                 {
                   output_directory: '.'

--- a/spec/correcting_scan_helper_spec.rb
+++ b/spec/correcting_scan_helper_spec.rb
@@ -646,7 +646,7 @@ describe TestCenter do
                 raise FastlaneCore::Interface::FastlaneTestFailure, 'failed tests'
               end
 
-              expect(Fastlane::Actions).to receive(:sh)
+              expect(Fastlane::Actions).to receive(:sh).with(/killall -9 'iPhone Simulator' 'Simulator' 'SimulatorBridge'.*/, anything).at_least(3).times
               result = scanner.correcting_scan(
                 {
                   output_directory: '.'


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

Hello 👋 there,

Thanks for all the hard work in this library, it has been saving me from a lot of pain in my tests suites 😅.

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [ ] I've updated the documentation if necessary.

### Motivation and Context
The main motivation for this PR is regarding running UI tests with a predefined location. We can use this very good [repository](https://github.com/lyft/set-simulator-location) from Lyft to set a location in the simulator before running the tests but the simulator needs to be kept open before running the tests, otherwise, the simulator would fail in setting the location and tests would fail.

The behavior of `scan` by default is to keep the simulator in his current state (I tested several times)

### Description
Add the new `quit_simulators` parameter to avoid the simulator being shutting down before running the tests. Resolve #88.

I set the name `quit_simulators` but I don't have any problem if we decided a better name. About docs, I'm not sure exactly in which part we should specify this new parameter but I think we should so I'm open to suggestions 😁.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md