### PR TITLE
Fix collating of batched reports

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/collate_html_reports.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_html_reports.rb
@@ -161,7 +161,7 @@ module Fastlane
 
       # :nocov:
       def self.description
-        "Combines and combines tests from multiple html report files"
+        "Combines multiple html report files into one html report file"
       end
 
       def self.details

--- a/lib/fastlane/plugin/test_center/actions/collate_json_reports.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_json_reports.rb
@@ -100,7 +100,7 @@ module Fastlane
 
       # :nocov:
       def self.description
-        "Combines and combines tests from multiple json report files"
+        "Combines multiple json report files into one json report file"
       end
 
       def self.details

--- a/lib/fastlane/plugin/test_center/actions/collate_junit_reports.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_junit_reports.rb
@@ -149,7 +149,7 @@ module Fastlane
       #####################################################
       # :nocov:
       def self.description
-        "Combines and combines tests from multiple junit report files"
+        "Combines multiple junit report files into one junit report file"
       end
 
       def self.details

--- a/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
@@ -113,7 +113,7 @@ module Fastlane
 
       # :nocov:
       def self.description
-        "Combines and combines tests from multiple test_result bundles"
+        "Combines multiple test_result bundles into one test_result bundle"
       end
 
       def self.details

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -175,8 +175,7 @@ module Fastlane
 
       # :nocov:
       def self.description
-        "Uses scan to run Xcode tests a given number of times, with the option " \
-        "of batching them, only re-testing failing tests."
+        "Uses scan to run Xcode tests a given number of times, with the option of batching and/or parallelizing them, only re-testing failing tests."
       end
 
       def self.details

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/parallel_test_batch_worker.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/parallel_test_batch_worker.rb
@@ -17,7 +17,7 @@ module TestCenter
         def process_results
           @pid = nil
           File.foreach(@log_filepath) do |line|
-            puts "[worker #{@options[:batch_index]}] #{line}"
+            puts "[worker #{@options[:batch_index] + 1}] #{line}"
           end
           state = :ready_to_work
           @options[:test_batch_results] << (@reader.gets == 'true')
@@ -32,6 +32,9 @@ module TestCenter
             begin
               reroute_stdout_to_logfile
               tests_passed = super(run_options)
+            rescue StandardError => e
+              puts e.message
+              puts e.backtrace.inspect
             ensure
               handle_child_process_results(tests_passed)
               exit!
@@ -44,7 +47,7 @@ module TestCenter
           @reader, @writer = IO.pipe
           @log_filepath = File.join(
             Dir.mktmpdir,
-            "parallel-test-batch-#{@options[:batch_index]}.txt"
+            "parallel-test-batch-#{@options[:batch_index] + 1}.txt"
           )
         end
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -45,12 +45,7 @@ module TestCenter
         end
 
         def output_directory
-          absolute_output_directory = File.absolute_path(@options[:output_directory])
-          if @options[:batch]
-            testable = @options.fetch(:only_testing, ['']).first.split('/').first || ''
-            absolute_output_directory = File.join(absolute_output_directory, "#{testable}-batch-#{@options[:batch]}")
-          end
-          absolute_output_directory
+          @options.fetch(:output_directory, 'test_results')
         end
 
         def print_starting_scan_message
@@ -220,7 +215,7 @@ module TestCenter
               Fastlane::Actions::RestartCoreSimulatorServiceAction.run
             end
           else
-            FastlaneCore::UI.error(test_operation_failure)
+            FastlaneCore::UI.error(test_session_last_messages)
             send_callback_testrun_info(test_operation_failure: test_operation_failure)
             raise exception
           end

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/simulator_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/simulator_helper.rb
@@ -28,7 +28,7 @@ module TestCenter
             original_simulators.each do |simulator|
               FastlaneCore::UI.verbose("Cloning simulator")
               cloned_simulator = simulator.clone
-              new_first_name = simulator.name.sub(/( ?\(.*| ?$)/, " Clone #{batch_index}")
+              new_first_name = simulator.name.sub(/( ?\(.*| ?$)/, " Clone #{batch_index + 1}")
               new_last_name = "#{self.class.name}<#{self.object_id}>"
               cloned_simulator.rename("#{new_first_name} #{new_last_name}")
 

--- a/spec/multi_scan_manager/parallel_test_batch_worker_spec.rb
+++ b/spec/multi_scan_manager/parallel_test_batch_worker_spec.rb
@@ -41,7 +41,7 @@ module TestCenter::Helper::MultiScanManager
 
     describe '#process_results' do
       it 'resets :pid when done' do
-        worker = ParallelTestBatchWorker.new({ test_batch_results: [] })
+        worker = ParallelTestBatchWorker.new({ test_batch_results: [], batch_index: 2 })
         allow(Process).to receive(:fork).and_return(11)
         allow(File).to receive(:foreach).and_yield('')
         worker.run({})
@@ -63,7 +63,7 @@ module TestCenter::Helper::MultiScanManager
         worker.open_interprocess_communication
         
         mock_logfile = OpenStruct.new
-        expect(File).to receive(:open).with('path/to/tmpfile/parallel-test-batch-5.txt', 'w').and_return(mock_logfile)
+        expect(File).to receive(:open).with('path/to/tmpfile/parallel-test-batch-6.txt', 'w').and_return(mock_logfile)
         expect(pipes[0]).to receive(:close)
 
         expect($stdout).to receive(:reopen).with(mock_logfile)

--- a/spec/multi_scan_manager/retrying_scan_helper_spec.rb
+++ b/spec/multi_scan_manager/retrying_scan_helper_spec.rb
@@ -23,7 +23,7 @@ module TestCenter::Helper::MultiScanManager
         allow(Dir).to receive(:glob).with(%r{/.*/path/to/AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr/.*\.xcresult}).and_return(['./AtomicDragon.xcresult'])
         helper = RetryingScanHelper.new(
           derived_data_path: 'path/to/AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory'
+          output_directory: File.absolute_path('./path/to/output/directory')
         )
         expect(FileUtils).to receive(:rm_rf).with(['./AtomicDragon.xcresult'])
         helper.before_testrun
@@ -32,7 +32,7 @@ module TestCenter::Helper::MultiScanManager
       it 'prints to the console a message that a test_run is being started' do
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           only_testing: [
             'BagOfTests/CoinTossingUITests/testResultIsTails',
             'BagOfTests/CoinTossingUITests/testResultIsHeads',
@@ -46,7 +46,7 @@ module TestCenter::Helper::MultiScanManager
       it 'prints to the console a message that a test_run for a batch is being started' do
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           only_testing: [
             'BagOfTests/CoinTossingUITests/testResultIsTails',
             'BagOfTests/CoinTossingUITests/testResultIsHeads',
@@ -144,7 +144,7 @@ module TestCenter::Helper::MultiScanManager
         allow(FileUtils).to receive(:mkdir_p)
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           result_bundle: true
         )
         expect(File).to receive(:rename).with('./AtomicDragon.test_result', './AtomicDragon-1.test_result')
@@ -160,7 +160,7 @@ module TestCenter::Helper::MultiScanManager
         allow(ENV).to receive(:[]=).and_call_original
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           output_types: 'json',
           output_files: 'report.json'
         )
@@ -189,7 +189,7 @@ module TestCenter::Helper::MultiScanManager
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           scheme: 'AtomicUITests',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           collate_reports: true
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
@@ -218,7 +218,7 @@ module TestCenter::Helper::MultiScanManager
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           scheme: 'AtomicUITests',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           collate_reports: true
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
@@ -241,7 +241,7 @@ module TestCenter::Helper::MultiScanManager
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           scheme: 'AtomicUITests',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory/BagOfTests-batch-2'),
           only_testing: ['BagOfTests/CoinTossingUITests/testResultIsTails'],
           batch: 2,
           batch_count: 3,
@@ -299,7 +299,7 @@ module TestCenter::Helper::MultiScanManager
       it 'has only the failing tests' do
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           only_testing: [
             'BagOfTests/CoinTossingUITests/testResultIsTails',
             'BagOfTests/CoinTossingUITests/testResultIsHeads'
@@ -325,7 +325,7 @@ module TestCenter::Helper::MultiScanManager
 
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           only_testing: [
             'BagOfTests/CoinTossingUITests/testResultIsTails',
             'BagOfTests/CoinTossingUITests/testResultIsHeads'
@@ -365,7 +365,7 @@ module TestCenter::Helper::MultiScanManager
 
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory/BagOfTests-batch-3'),
           only_testing: [
             'BagOfTests/CoinTossingUITests/testResultIsTails',
             'BagOfTests/CoinTossingUITests/testResultIsHeads'
@@ -407,7 +407,7 @@ module TestCenter::Helper::MultiScanManager
 
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           only_testing: [
             'BagOfTests/CoinTossingUITests/testResultIsTails',
             'BagOfTests/CoinTossingUITests/testResultIsHeads'
@@ -433,24 +433,16 @@ module TestCenter::Helper::MultiScanManager
         )
       end
 
-      it 'has the correct output_directory' do
-        helper = RetryingScanHelper.new(
-          derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory'
-        )
-        expect(helper.scan_options[:output_directory]).to match(%r{.*/path/to/output/directory})
-      end
-
       it 'has the correct result_bundle option' do
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           result_bundle: true
         )
         expect(helper.scan_options[:result_bundle]).to be_truthy
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory'
+          output_directory: File.absolute_path('./path/to/output/directory')
         )
         expect(helper.scan_options[:result_bundle]).to be_falsey
       end
@@ -458,7 +450,7 @@ module TestCenter::Helper::MultiScanManager
       it 'has the correct buildlog_path option' do
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           buildlog_path: './path/to/output/build_log/directory'
         )
         expect(helper.scan_options[:buildlog_path]).to eq('./path/to/output/build_log/directory')
@@ -468,7 +460,7 @@ module TestCenter::Helper::MultiScanManager
         expect {
           RetryingScanHelper.new(
             derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-            output_directory: './path/to/output/directory',
+            output_directory: File.absolute_path('./path/to/output/directory'),
             device: 'iPhone 6'
           )
         }.to(
@@ -479,7 +471,7 @@ module TestCenter::Helper::MultiScanManager
         expect {
           RetryingScanHelper.new(
             derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-            output_directory: './path/to/output/directory',
+            output_directory: File.absolute_path('./path/to/output/directory'),
             devices: ['iPhone 6', 'iPad Air']
           )
         }.to(
@@ -492,7 +484,7 @@ module TestCenter::Helper::MultiScanManager
       it 'has the correct destination option' do
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           destination: ['platform=iOS Simulator,id=0D312041-2D60-4221-94CC-3B0040154D74']
         )
         expect(helper.scan_options[:destination]).to eq(['platform=iOS Simulator,id=0D312041-2D60-4221-94CC-3B0040154D74'])
@@ -501,7 +493,7 @@ module TestCenter::Helper::MultiScanManager
       it 'has the correct scheme option' do
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           scheme: 'Thundercats'
         )
         expect(helper.scan_options[:scheme]).to eq('Thundercats')
@@ -510,7 +502,7 @@ module TestCenter::Helper::MultiScanManager
       it 'has the correct code_coverage option on the first run' do
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           code_coverage: true
         )
         expect(helper.scan_options[:code_coverage]).to eq(true)
@@ -525,7 +517,7 @@ module TestCenter::Helper::MultiScanManager
         
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           code_coverage: true
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
@@ -547,7 +539,7 @@ module TestCenter::Helper::MultiScanManager
 
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           testrun_completed_block: test_run_block
         )
         helper.after_testrun
@@ -575,7 +567,7 @@ module TestCenter::Helper::MultiScanManager
 
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           testrun_completed_block: test_run_block
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
@@ -606,7 +598,7 @@ module TestCenter::Helper::MultiScanManager
 
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           testrun_completed_block: test_run_block
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneBuildFailure.new('test failure'))
@@ -637,7 +629,7 @@ module TestCenter::Helper::MultiScanManager
 
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          output_directory: './path/to/output/directory',
+          output_directory: File.absolute_path('./path/to/output/directory'),
           testrun_completed_block: test_run_block
         )
         expect {

--- a/spec/multi_scan_manager/simulator_helper_spec.rb
+++ b/spec/multi_scan_manager/simulator_helper_spec.rb
@@ -88,7 +88,7 @@ module TestCenter::Helper::MultiScanManager
         ]
         (0...4).each do |index|
           expect(original_device).to receive(:clone).and_return(cloned_simulators[index])
-          expect(cloned_simulators[index]).to receive(:rename).with(/iPad Pro Clone #{index} TestCenter::Helper::MultiScanManager::SimulatorHelper<\d+>/)
+          expect(cloned_simulators[index]).to receive(:rename).with(/iPad Pro Clone #{index + 1} TestCenter::Helper::MultiScanManager::SimulatorHelper<\d+>/)
         end
         result = helper.clone_destination_simulators
         expect(result).to eq(cloned_simulators.map { |s| [ s ] })


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes issue [Parallelization Bug: reports for batches with spaces in the testable name are not collated properly](https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/issues/109)

### Description
<!-- Describe your changes in detail -->

Fix a couple of issues:
1. spaces in names of testables would break the final collation
2. the first batch report was not generated in a testable-subdirectory
3. the final report for a single testable was not placed in the expected
place, breaking CI expecting the final report to be there and be fully
collated.


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md