### PR TITLE
issue-111 pre-boot cloned simulators

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker_pool.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker_pool.rb
@@ -30,6 +30,9 @@ module TestCenter
           at_exit do
             clean_up_cloned_simulators(@clones) if Process.pid == main_pid
           end
+          # boot all the simulators _before_ calling `xcodebuilt test` to avoid
+          # testmanagerd connection failures.
+          @clones.flatten.each(&:boot)
           @clones
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Sometimes, while using the `parallel_testrun_count` option, all parallel test runs will fail with an error that the simulator failed to boot and that the testmanagerd failed to connect.

### Description
<!-- Describe your changes in detail -->

I had forgotten to include the pre-boot of the cloned Simulators in my refactoring of the parallelization of mulit_scan. This change includes the pre-boot of all cloned simulators. It does slow down the process initially, but provides a much higher degree of success.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md