### PR TITLE
issue-113 fix parallelized invocation based tests

### DIFF
--- a/AtomicBoy/KiwiTests/KiwiTests.m
+++ b/AtomicBoy/KiwiTests/KiwiTests.m
@@ -18,4 +18,146 @@ describe(@"KiwiDemoTests", ^{
     });
 });
 
+describe(@"KiwiDemoTests", ^{
+    context(@"test1", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"KiwiDemoTests", ^{
+    context(@"test2", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"KiwiDemoTests", ^{
+    context(@"test3", ^{
+        it(@"2 + 2 = 5", ^{
+            [[theValue(2 + 2) should] equal:theValue(5)];
+        });
+    });
+});
+
+SPEC_END
+
+SPEC_BEGIN(SmallBirdTests)
+
+describe(@"(SmallBirdTests)", ^{
+    context(@"test", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"(SmallBirdTests)", ^{
+    context(@"test1", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"(SmallBirdTests)", ^{
+    context(@"test2", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"(SmallBirdTests)", ^{
+    context(@"test3", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"(SmallBirdTests)", ^{
+    context(@"test4", ^{
+        it(@"2 + 2 = 5", ^{
+            [[theValue(2 + 2) should] equal:theValue(5)];
+        });
+    });
+});
+
+SPEC_END
+
+
+SPEC_BEGIN(PumpkinTests)
+
+describe(@"PumpkinTests", ^{
+    context(@"test", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"PumpkinTests", ^{
+    context(@"test1", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"PumpkinTests", ^{
+    context(@"test2", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"PumpkinTests", ^{
+    context(@"test3", ^{
+        it(@"2 + 2 = 5", ^{
+            [[theValue(2 + 2) should] equal:theValue(5)];
+        });
+    });
+});
+
+SPEC_END
+
+
+SPEC_BEGIN(CruddogTests)
+
+describe(@"CruddogTests", ^{
+    context(@"test", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"CruddogTests", ^{
+    context(@"test1", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"CruddogTests", ^{
+    context(@"test2", ^{
+        it(@"2 + 2 = 4", ^{
+            [[theValue(2 + 2) should] equal:theValue(4)];
+        });
+    });
+});
+
+describe(@"CruddogTests", ^{
+    context(@"test3", ^{
+        it(@"2 + 2 = 5", ^{
+            [[theValue(2 + 2) should] equal:theValue(5)];
+        });
+    });
+});
+
 SPEC_END

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -49,7 +49,11 @@ module TestCenter
         end
 
         def print_starting_scan_message
-          scan_message = "Starting scan ##{@testrun_count + 1} with #{@options.fetch(:only_testing, []).size} tests"
+          if @options[:only_testing]
+            scan_message = "Starting scan ##{@testrun_count + 1} with #{@options.fetch(:only_testing, []).size} tests"
+          else
+            scan_message = "Starting scan ##{@testrun_count + 1}"
+          end
           scan_message << " for batch ##{@options[:batch]}" unless @options[:batch].nil?
           FastlaneCore::UI.message("#{scan_message}.")
         end
@@ -117,7 +121,6 @@ module TestCenter
 
         def handle_test_failure
           send_callback_testrun_info
-          reset_simulators
           move_test_result_bundle_for_next_run
           update_scan_options
           @reportnamer.increment
@@ -189,12 +192,6 @@ module TestCenter
             @options[:only_testing] = @options[:only_testing].map(&:strip_testcase).uniq
           end
         end
-        
-        def reset_simulators
-          return unless @options[:reset_simulators]
-
-          @options[:simulators].each(&:reset)
-        end
 
         def handle_build_failure(exception)
           test_operation_failure = ''
@@ -218,11 +215,6 @@ module TestCenter
             FastlaneCore::UI.error(test_session_last_messages)
             send_callback_testrun_info(test_operation_failure: test_operation_failure)
             raise exception
-          end
-          if @options[:reset_simulators]
-            @options[:simulators].each do |simulator|
-              simulator.reset
-            end
           end
           send_callback_testrun_info(test_operation_failure: test_operation_failure)
         end

--- a/spec/multi_scan_manager/retrying_scan_helper_spec.rb
+++ b/spec/multi_scan_manager/retrying_scan_helper_spec.rb
@@ -104,35 +104,6 @@ module TestCenter::Helper::MultiScanManager
         helper.after_testrun(FastlaneCore::Interface::FastlaneBuildFailure.new('test failure'))
       end
 
-      it 'resets the simulators' do
-        cloned_simulators = [
-          OpenStruct.new(name: 'Clone 1'),
-          OpenStruct.new(name: 'Clone 2')
-        ]
-        helper = RetryingScanHelper.new(
-          derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
-          simulators: cloned_simulators,
-          reset_simulators: true,
-          output_directory: ''
-        )
-        
-        session_log_io = StringIO.new('Test operation failure: Test runner exited before starting test execution')
-        allow(session_log_io).to receive(:stat).and_return(OpenStruct.new(size: session_log_io.size))
-  
-        allow(Dir).to receive(:glob)
-                  .with(%r{.*AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr/Logs/Test/\*\.xcresult/\*_Test/Diagnostics/\*\*/Session-\*\.log})
-                  .and_return(['A/B/C/Session-AtomicBoyUITests-Today.log', 'D/E/F/Session-AtomicBoyUITests-Today.log'])
-  
-        allow(File).to receive(:mtime).with('A/B/C/Session-AtomicBoyUITests-Today.log').and_return(1)
-        allow(File).to receive(:mtime).with('D/E/F/Session-AtomicBoyUITests-Today.log').and_return(2)
-        allow(File).to receive(:open).with('D/E/F/Session-AtomicBoyUITests-Today.log').and_return(session_log_io)
-        
-        cloned_simulators.each do |cloned_simulator|
-          expect(cloned_simulator).to receive(:reset)
-        end
-        helper.after_testrun(FastlaneCore::Interface::FastlaneBuildFailure.new('test failure'))
-      end
-
       it 'renames the resultant test bundle after failure' do
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{.*/path/to/output/directory/report(-\d)?\.junit}).and_return(true)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes [Issue 113 ](https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/issues/113) by properly setting up parameters for the initial run of invocation based tests and parallelizes subsequent runs of failed test suites.

### Description
<!-- Describe your changes in detail -->

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md