### PR TITLE
issue-117 fix parallel test runs returning false

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/parallel_test_batch_worker.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/parallel_test_batch_worker.rb
@@ -34,7 +34,8 @@ module TestCenter
             print line
           end
           state = :ready_to_work
-          @options[:test_batch_results] << (@reader.gets == 'true')
+
+          @options[:test_batch_results] << (@reader.gets.chomp.to_s == 'true')
         end
 
         def run(run_options)
@@ -50,11 +51,16 @@ module TestCenter
               puts e.message
               puts e.backtrace.inspect
             ensure
+              print_final_results(tests_passed)
               handle_child_process_results(tests_passed)
               exit!
             end
           end
           close_parent_process_writer
+        end
+
+        def print_final_results(tests_passed)
+          FastlaneCore::UI.verbose("All tests passed for batch #{@options[:batch_index] + 1}? #{tests_passed}")
         end
 
         def open_interprocess_communication

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -133,6 +133,7 @@ module TestCenter
           end
           pool.wait_for_all_workers
           collate_batched_reports
+          FastlaneCore::UI.verbose("Results for each test run: #{test_batch_results}")
           test_batch_results.reduce(true) { |a, t| a && t }
         end
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -134,7 +134,7 @@ module TestCenter
           pool.wait_for_all_workers
           collate_batched_reports
           FastlaneCore::UI.verbose("Results for each test run: #{test_batch_results}")
-          test_batch_results.reduce(true) { |a, t| a && t }
+          test_batch_results.all?
         end
 
         def scan_options_for_worker(test_batch, batch_index)

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker.rb
@@ -15,8 +15,10 @@ module TestCenter
 
         def run(run_options)
           self.state = :working
-          @options[:test_batch_results] << RetryingScan.run(@options.merge(run_options))
+          test_batch_worker_final_result = RetryingScan.run(@options.merge(run_options))
+          @options[:test_batch_results] << test_batch_worker_final_result
           self.state = :ready_to_work
+          test_batch_worker_final_result
         end
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes an issue where parallel test runs would return _only_ return false. It was impossible for it to return the true result.

### Description
<!-- Describe your changes in detail -->

1. Add tests that confirm that the code was broken, and then confirmed that the new code fixes the test.
2. Fix test worker to actually get the test run status rather than the worker's `:state`.
3. Fix the parallel test work to properly test the pipe's result. Before, it had a new line as that is what `puts` does. I remove any newlines before comparing the result to `true`.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md