### PR TITLE
issue-41 support skip_build

### DIFF
--- a/spec/multi_scan_manager/runner_spec.rb
+++ b/spec/multi_scan_manager/runner_spec.rb
@@ -83,8 +83,8 @@ module TestCenter::Helper::MultiScanManager
         @xctest_runner.run
       end
 
-      it 'runs invocation tests when appropriate' do
-        invocation_runner = Runner.new(
+      it 'runs :run_tests_through_single_try when given :invocation_based_tests' do
+        runner = Runner.new(
           {
             output_directory: './path/to/output/directory',
             scheme: 'AtomicUITests',
@@ -92,12 +92,26 @@ module TestCenter::Helper::MultiScanManager
             invocation_based_tests: true
           }
         )
-        expect(invocation_runner).to receive(:run_first_run_of_invocation_based_tests)
-        expect(invocation_runner).to receive(:run_test_batches)
-        invocation_runner.run
+        expect(runner).to receive(:run_tests_through_single_try)
+        expect(runner).to receive(:run_test_batches)
+        runner.run
       end
 
-      it 'does not run invocation tests when not appropriate' do
+      it 'runs :run_tests_through_single_try when given :skip_build' do
+        runner = Runner.new(
+          {
+            output_directory: './path/to/output/directory',
+            scheme: 'AtomicUITests',
+            try_count: 2,
+            skip_build: true
+          }
+        )
+        expect(runner).to receive(:run_tests_through_single_try)
+        expect(runner).to receive(:run_test_batches)
+        runner.run
+      end
+
+      it 'does not run single_try_scan when not appropriate' do
         invocation_runner = Runner.new(
           {
             output_directory: './path/to/output/directory',
@@ -112,7 +126,7 @@ module TestCenter::Helper::MultiScanManager
             ]
           }
         )
-        expect(invocation_runner).not_to receive(:run_invocation_based_tests)
+        expect(invocation_runner).not_to receive(:run_tests_through_single_try)
         expect(invocation_runner).to receive(:run_test_batches)
         invocation_runner.run
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Users want the `:skip_build` option supported to let `xcodebuild` decide when to build or not. Previously, I did not support this as I wanted to use the `xctestrun` file to inform which tests should run. 

### Description
<!-- Describe your changes in detail -->

Change the single run of scan to run for both invocation tests and skip_build tests.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md