### PR TITLE
Issue 75 only testing expecting array

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -16,6 +16,9 @@ module TestCenter
           FastlaneCore::UI.user_error!("Error: cannot find xctestrun file '#{@xctestrun_path}'")
         end
         @only_testing = options[:only_testing]
+        if @only_testing.kind_of?(String)
+          @only_testing = @only_testing.split(',')
+        end
         @skip_testing = options[:skip_testing]
         @invocation_based_tests = options[:invocation_based_tests]
         @batch_count = options[:batch_count]

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -66,6 +66,17 @@ module TestCenter::Helper
           expect(result).to include('AtomicBoyTests', 'AtomicBoyUITests')
         end
 
+        it 'calls to testables :only_testing with a String returns an array with a testable' do
+          expect(Plist).not_to receive(:parse_xml)
+          expect(Fastlane::Actions::TestsFromXctestrunAction).not_to receive(:run)
+          test_collector = TestCollector.new(
+            xctestrun: 'path/to/fake.xctestrun',
+            only_testing: 'AtomicBoyTests'
+          )
+          result = test_collector.testables
+          expect(result).to include('AtomicBoyTests')
+        end
+
         it 'calls to testables_tests returns Hash of only_testing' do
           expect(Fastlane::Actions::TestsFromXctestrunAction).not_to receive(:run)
           test_collector = TestCollector.new(


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

fastlane's `scan` supports receiving a String for the `:only_testing` option. `multi_scan` crashes with such a parameter.

### Description
<!-- Describe your changes in detail -->

Convert the the `:only_testing` parameter to an `Array` if it is a `String`. Add a test.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md