### PR TITLE
Issue-124 total retry count is nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ lane :sweep do
     try_count: 3,
     fail_build: false,
     scheme: 'AtomicBoy',
-    testrun_completed_block: test_run_block
+    testrun_completed_block: test_run_block,
+    parallel_testrun_count: 4
   )
   unless result[:failed_testcount].zero?
     UI.message("There are #{result[:failed_testcount]} legitimate failing tests")

--- a/lib/fastlane/plugin/test_center/actions/collate_junit_reports.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_junit_reports.rb
@@ -11,10 +11,10 @@ module Fastlane
           reports = report_filepaths.map { |report_filepath| REXML::Document.new(File.new(report_filepath)) }
           # copy any missing testsuites
           target_report = reports.shift
-          target_report.root.attributes['retries'] = reports.size.to_s
           preprocess_testsuites(target_report)
 
           reports.each do |report|
+            increment_testable_tries(target_report.root, report.root)
             preprocess_testsuites(report)
             UI.verbose("> collating last report file #{report_filepaths.last}")
             report.elements.each('//testsuite') do |testsuite|
@@ -107,6 +107,13 @@ module Fastlane
             target_testsuite << testcase
           end
         end
+      end
+
+      def self.increment_testable_tries(target_testable, other_testable)
+        try_count = target_testable.attributes['retries'] || 1
+        other_try_count = other_testable['retries'] || 1
+
+        target_testable.attributes['retries'] = (try_count.to_i + other_try_count.to_i).to_s
       end
 
       def self.increment_testcase_tries(target_testcase, testcase)

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -97,6 +97,7 @@ module TestCenter
           move_simulator_logs_for_next_run
 
           @testrun_count = @testrun_count + 1
+          FastlaneCore::UI.verbose("Batch ##{@options[:batch]} incrementing retry count to #{@testrun_count}")
           if exception.kind_of?(FastlaneCore::Interface::FastlaneTestFailure)
             after_testrun_message = "Scan found failing tests"
             after_testrun_message << " for batch ##{@options[:batch]}" unless @options[:batch].nil?

--- a/spec/collate_junit_reports_spec.rb
+++ b/spec/collate_junit_reports_spec.rb
@@ -244,6 +244,6 @@ describe Fastlane::Actions::CollateJunitReportsAction do
     testExample4 = REXML::XPath.first(report, "//testcase[@classname='AtomicBoyUITests'][@name='testExample4']")
     expect(testExample4.attributes['retries']).to eq('2')
 
-    expect(report.root.attributes['retries']).to eq('2')
+    expect(report.root.attributes['retries']).to eq('3')
   end
 end

--- a/spec/multi_scan_spec.rb
+++ b/spec/multi_scan_spec.rb
@@ -108,8 +108,7 @@ module Fastlane::Actions
             output_files: 'report.xml',
             output_directory: 'test_output'
           },
-          true,
-          1
+          true
         )
         expect(summary).to include(
           result: true,
@@ -168,8 +167,7 @@ module Fastlane::Actions
             output_files: 'report.xml',
             output_directory: 'test_output'
           },
-          false,
-          2
+          false
         )
         expect(summary).to include(
           result: false,
@@ -192,7 +190,7 @@ module Fastlane::Actions
               location: 'AtomicBoy.m:38'
             }
           },
-          total_retry_count: 2
+          total_retry_count: 1
         )
       end
 
@@ -214,8 +212,7 @@ module Fastlane::Actions
             output_directory: 'test_output',
             result_bundle: true
           },
-          true,
-          1
+          true
         )
         expect(summary).to include(
           result: true,


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes an issue where the `multi_scan` summary contains `nil` for the total retry count.

### Description
<!-- Describe your changes in detail -->

1. Update how we collate junit reports to update the retry count by taking into account the number of reports were used to collate into the main one.
2. Gather the retry count from the junit report rather than depending on the runner's retry counts.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md