### PR TITLE
issue-132 populate known_tests with all tests

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -73,11 +73,11 @@ module TestCenter
       def expand_testsuites_to_tests
         return if @invocation_based_tests
 
-        known_tests = nil
+        known_tests = []
         @testables_tests.each do |testable, tests|
           tests.each_with_index do |test, index|
             if test.count('/') < 2
-              known_tests ||= xctestrun_known_tests[testable]
+              known_tests += xctestrun_known_tests[testable]
               test_components = test.split('/')
               testsuite = test_components.size == 1 ? test_components[0] : test_components[1]
               @testables_tests[testable][index] = known_tests.select { |known_test| known_test.include?(testsuite) } 

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -99,17 +99,69 @@ module TestCenter::Helper
           )
         end
 
-        it 'calls to testables_tests returns Hash of only_testing' do
+        it 'calls to testables_tests with only_testing single target returns Hash of only_testing' do
           test_collector = TestCollector.new(
             xctestrun: 'path/to/fake.xctestrun',
-            only_testing: ['AtomicBoyTests']
+            only_testing: ['AtomicBoyUITests']
           )
           allow(test_collector).to receive(:xctestrun_known_tests).and_return(
-            'AtomicBoyTests' => ['AtomicBoyTests']
+            'AtomicBoyTests' => [
+              'AtomicBoyTests/AtomicBoyTests/testExample1',
+              'AtomicBoyTests/AtomicBoyTests/testExample2',
+              'AtomicBoyTests/AtomicBoyTests/testExample3',
+              'AtomicBoyTests/AtomicBoyTests/testExample4'
+            ],
+            'AtomicBoyUITests' => [
+              'AtomicBoyUITests/AtomicBoyUITests/testExample1',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample2',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample3',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample4'
+            ]
           )
           result = test_collector.testables_tests
           expect(result).to include(
-            'AtomicBoyTests' => ['AtomicBoyTests']
+            'AtomicBoyUITests' => [
+              'AtomicBoyUITests/AtomicBoyUITests/testExample1',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample2',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample3',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample4'
+            ]
+          )
+        end
+
+        it 'calls to testables_tests with only_testing multiple targets returns Hash of only_testing' do
+          test_collector = TestCollector.new(
+            xctestrun: 'path/to/fake.xctestrun',
+            only_testing: ['AtomicBoyTests', 'AtomicBoyUITests']
+          )
+          allow(test_collector).to receive(:xctestrun_known_tests).and_return(
+            'AtomicBoyTests' => [
+              'AtomicBoyTests/AtomicBoyTests/testExample1',
+              'AtomicBoyTests/AtomicBoyTests/testExample2',
+              'AtomicBoyTests/AtomicBoyTests/testExample3',
+              'AtomicBoyTests/AtomicBoyTests/testExample4'
+            ],
+            'AtomicBoyUITests' => [
+              'AtomicBoyUITests/AtomicBoyUITests/testExample1',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample2',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample3',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample4'
+            ]
+          )
+          result = test_collector.testables_tests
+          expect(result).to include(
+            'AtomicBoyTests' => [
+              'AtomicBoyTests/AtomicBoyTests/testExample1',
+              'AtomicBoyTests/AtomicBoyTests/testExample2',
+              'AtomicBoyTests/AtomicBoyTests/testExample3',
+              'AtomicBoyTests/AtomicBoyTests/testExample4'
+            ],
+            'AtomicBoyUITests' => [
+              'AtomicBoyUITests/AtomicBoyUITests/testExample1',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample2',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample3',
+              'AtomicBoyUITests/AtomicBoyUITests/testExample4'
+            ]
           )
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
This resolves #132, which is a regression in 3.8.0 where using the `only_testing` option with multiple test targets results in the tests only being collected from one of the targets.

I've tested this change locally on a project with several test targets and have verified that it works now as expected.

I'd like to add test coverage for this PR, since this regression wasn't caught by the existing tests, but I had a hard time figuring out the best way to simulate this scenario, and would love feedback or assistance so I can make sure this change is covered properly.

### Description
<!-- Describe your changes in detail -->
This change simply changes the initializer of `known_tests` to an empty array, and changes the `||=` operator to `+=` to correctly collect the tests.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md