### PR TITLE
issue-131 fix REXML@2.3.0 attributes[''] crash

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/collate_html_reports.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_html_reports.rb
@@ -64,7 +64,7 @@ module Fastlane
       end
 
       def self.testsuite_from_report(report, testsuite)
-        testsuite_name = testsuite.attributes['id']
+        testsuite_name = testsuite.attribute('id').value
         REXML::XPath.first(report, "//section[contains(@class, 'test-suite') and @id='#{testsuite_name}']")
       end
 
@@ -117,11 +117,11 @@ module Fastlane
           failing_tests_xpath = "./*[contains(@class, 'tests')]//*[" \
                 "contains(@class, 'failing')]"
 
-          class_attributes = testsuite.attributes['class']
+          class_attributes = testsuite.attribute('class').value
           test_failures = REXML::XPath.match(testsuite, failing_tests_xpath)
           test_status = test_failures.size.zero? ? 'passing' : 'failing'
 
-          testsuite.attributes['class'] = class_attributes.sub('failing', test_status)
+          testsuite.add_attribute('class', class_attributes.sub('failing', test_status))
         end
       end
 

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -73,7 +73,7 @@ module Fastlane
           failure_details.merge!(junit_results[:failure_details])
 
           report = REXML::Document.new(File.new(report_file))
-          retry_total_count += (report.root.attributes['retries'] || 1).to_i
+          retry_total_count += (report.root.attribute('retries')&.value || 1).to_i
         end
 
         if reportnamer.includes_html?

--- a/lib/fastlane/plugin/test_center/helper/junit_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/junit_helper.rb
@@ -32,7 +32,7 @@ module TestCenter
         end
 
         def name
-          return @root.attributes['name']
+          return @root.attribute('name').value
         end
 
         def testsuites
@@ -50,7 +50,7 @@ module TestCenter
         end
 
         def name
-          return @root.attributes['name']
+          return @root.attribute('name').value
         end
 
         def identifier
@@ -74,17 +74,17 @@ module TestCenter
 
         def initialize(xml_element)
           @root = xml_element
-          name = xml_element.attributes['name']
+          name = xml_element.attribute('name').value
           failure_element = xml_element.elements['failure']
           if failure_element
-            @message = failure_element.attributes['message'] || ''
+            @message = failure_element.attribute('message')&.value || ''
             @location = failure_element.text || ''
           end
-          full_testsuite = xml_element.parent.attributes['name']
+          full_testsuite = xml_element.parent.attribute('name').value
           testsuite = full_testsuite.testsuite
           is_swift = full_testsuite.testsuite_swift?
 
-          testable_filename = xml_element.parent.parent.attributes['name']
+          testable_filename = xml_element.parent.parent.attribute('name').value
           testable = File.basename(testable_filename, '.xctest')
           @identifier = "#{testable}/#{testsuite}/#{name}"
           @skipped_test = Xcodeproj::XCScheme::TestAction::TestableReference::SkippedTest.new

--- a/spec/collate_html_reports_spec.rb
+++ b/spec/collate_html_reports_spec.rb
@@ -8,7 +8,7 @@ def testidentifiers_from_xmlreport(report)
   testidentifiers = []
   testsuites.each do |testsuite|
     testidentifiers += REXML::XPath.match(testsuite, ".//*[contains(@class, 'tests')]//*[contains(@class, 'test')]//*[contains(@class, 'title')]").map do |testcase|
-      "#{testsuite.attributes['id']}/#{testcase.text.strip}"
+      "#{testsuite.attribute('id').value}/#{testcase.text.strip}"
     end
   end
   testidentifiers
@@ -79,12 +79,12 @@ describe Fastlane::Actions::CollateHtmlReportsAction do
       expect(failing_testcases.size).to eq(1)
       failing_testcase = failing_testcases.first
       failing_testclass = REXML::XPath.match(failing_testcase, "ancestor::*/*[contains(@class, 'test-suite')]")[0]
-      expect(failing_testclass.attributes['id']).to eq('AtomicBoyUITests')
+      expect(failing_testclass.attribute('id').value).to eq('AtomicBoyUITests')
       expect(failing_testcase.text.strip).to eq('testExample')
 
       failing_testcase_details = REXML::XPath.match(report, ".//*[contains(@class, 'tests')]//*[contains(@class, 'details') and contains(@class, 'failing')]")
       expect(failing_testcase_details.size).to eq(1)
-      failing_testcase_class = failing_testcase_details[0].attributes['class']
+      failing_testcase_class = failing_testcase_details[0].attribute('class').value
       expect(failing_testcase_class.split(' ')).to include('testExample')
 
       test_count = REXML::XPath.first(report, ".//*[@id='test-count']/span").text.strip

--- a/spec/collate_junit_reports_spec.rb
+++ b/spec/collate_junit_reports_spec.rb
@@ -131,7 +131,7 @@ describe Fastlane::Actions::CollateJunitReportsAction do
 
       testable = REXML::XPath.first(report, "//testsuites")
       testcases = REXML::XPath.match(testable, '*//testcase').map do |testcase|
-        "#{testcase.attributes['classname']}/#{testcase.attributes['name']}"
+        "#{testcase.attribute('classname')}/#{testcase.attribute('name').value}"
       end
       expect(testcases).to contain_exactly(
         'AtomicBoyTests/testExample',
@@ -140,11 +140,11 @@ describe Fastlane::Actions::CollateJunitReportsAction do
         'AtomicBoyUITests/testExample2'
       )
       failing_testcase = REXML::XPath.first(testable, '*//testcase/failure').parent
-      expect(failing_testcase.attributes['classname']).to eq('AtomicBoyUITests')
-      expect(failing_testcase.attributes['name']).to eq('testExample2')
+      expect(failing_testcase.attribute('classname').value).to eq('AtomicBoyUITests')
+      expect(failing_testcase.attribute('name').value).to eq('testExample2')
 
-      expect(testable.attributes['failures']).to eq('1')
-      expect(testable.attributes['tests']).to eq('4')
+      expect(testable.attribute('failures').value).to eq('1')
+      expect(testable.attribute('tests').value).to eq('4')
     end
 
     it 'updates failed tests in subsequent reports' do
@@ -174,7 +174,7 @@ describe Fastlane::Actions::CollateJunitReportsAction do
 
       testable = REXML::XPath.first(report, "//testsuites")
       testcases = REXML::XPath.match(testable, '*//testcase').map do |testcase|
-        "#{testcase.attributes['classname']}/#{testcase.attributes['name']}"
+        "#{testcase.attribute('classname')}/#{testcase.attribute('name').value}"
       end
       expect(testcases).to contain_exactly(
         'AtomicBoyTests/testExample',
@@ -183,8 +183,8 @@ describe Fastlane::Actions::CollateJunitReportsAction do
         'AtomicBoyUITests/testExample2'
       )
       expect(REXML::XPath.first(testable, '*//testcase/failure')).to be_nil
-      expect(testable.attributes['failures']).to eq('0')
-      expect(testable.attributes['tests']).to eq('4')
+      expect(testable.attribute('failures').value).to eq('0')
+      expect(testable.attribute('tests').value).to eq('4')
     end
   end
 
@@ -208,8 +208,8 @@ describe Fastlane::Actions::CollateJunitReportsAction do
     report = REXML::Document.new(report_file.string)
 
     testable = REXML::XPath.first(report, "//testsuites")
-    expect(testable.attributes['failures']).to eq('0')
-    expect(testable.attributes['tests']).to eq('173')
+    expect(testable.attribute('failures').value).to eq('0')
+    expect(testable.attribute('tests').value).to eq('173')
   end
 
   it 'updates the try counts' do
@@ -238,12 +238,12 @@ describe Fastlane::Actions::CollateJunitReportsAction do
     report = REXML::Document.new(report_file.string)
 
     testExample2 = REXML::XPath.first(report, "//testcase[@classname='AtomicBoyUITests'][@name='testExample2']")
-    expect(testExample2.attributes['retries']).to eq('2')
+    expect(testExample2.attribute('retries').value).to eq('2')
     testExample3 = REXML::XPath.first(report, "//testcase[@classname='AtomicBoyUITests'][@name='testExample3']")
-    expect(testExample3.attributes['retries']).to eq('1')
+    expect(testExample3.attribute('retries').value).to eq('1')
     testExample4 = REXML::XPath.first(report, "//testcase[@classname='AtomicBoyUITests'][@name='testExample4']")
-    expect(testExample4.attributes['retries']).to eq('2')
+    expect(testExample4.attribute('retries').value).to eq('2')
 
-    expect(report.root.attributes['retries']).to eq('3')
+    expect(report.root.attribute('retries').value).to eq('3')
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes an issue where the older REXML Element attributes['x'] call will fail with a `no implicit conversion of String into Integer` crash, Issue #131 .

### Description
<!-- Describe your changes in detail -->

Use the older, but still supported in `v2.4.1`, api for the `REXML::Element` `attribute()` and `add_attribute()` method. This method is supported in the Mac default version of Ruby `v2.3.0`.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md