### PR TITLE
Issue-126 fix html collation

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/html_test_report.rb
+++ b/lib/fastlane/plugin/test_center/helper/html_test_report.rb
@@ -1,0 +1,282 @@
+module TestCenter
+  module Helper
+    module HtmlTestReport
+      class Report
+        require 'rexml/formatters/transitive'
+
+        attr_reader :root
+        def initialize(html_file)
+          @root = html_file.root
+        end
+
+        def testsuites
+          testsuite_elements = REXML::XPath.match(@root, "//section[contains(@class, 'test-suite')]")
+          testsuite_elements.map do |testsuite_element|
+            TestSuite.new(testsuite_element)
+          end
+        end
+
+        def add_testsuite(testsuite)
+          testsuites_element = REXML::XPath.first(@root, ".//*[@id='test-suites']")
+          testsuites_element.push(testsuite.root)
+        end
+
+        def collate_report(report)
+          testsuites.each(&:remove_duplicate_testcases)
+          report.testsuites.each(&:remove_duplicate_testcases)
+          FastlaneCore::UI.verbose("TestCenter::Helper::HtmlTestReport::Report.collate_report to report:\n\t#{@root}")
+          report.testsuites.each do |given_testsuite|
+            existing_testsuite = testsuite_with_title(given_testsuite.title)
+            if existing_testsuite.nil?
+              FastlaneCore::UI.verbose("\tadding testsuite\n\t\t#{given_testsuite}")
+              add_testsuite(given_testsuite)
+            else
+              FastlaneCore::UI.verbose("\tcollating testsuite\n\t\t#{given_testsuite.root}")
+              existing_testsuite.collate_testsuite(given_testsuite)
+              FastlaneCore::UI.verbose("\tafter collation exiting testsuite\n\t\t#{existing_testsuite.root}")
+            end
+          end
+          update_test_count
+          update_fail_count
+        end
+
+        def testsuite_with_title(title)
+          testsuite_element = REXML::XPath.first(@root, ".//*[contains(@id, 'test-suites')]//*[@id='#{title}' and contains(concat(' ', @class, ' '), ' test-suite ')]")
+          TestSuite.new(testsuite_element) unless testsuite_element.nil?
+        end
+
+        def test_count
+          REXML::XPath.first(@root, ".//*[@id = 'counters']//*[@id='test-count']/*[@class = 'number']/text()").to_s.to_i
+        end
+      
+        def set_test_count(test_count)
+          test_count_element = REXML::XPath.first(@root, ".//*[@id = 'counters']//*[@id='test-count']/*[@class = 'number']/text()")
+          test_count_element.value = test_count.to_s
+        end
+
+        def update_test_count
+          testcase_elements = REXML::XPath.match(@root, ".//*[contains(@class, 'tests')]//*[contains(concat(' ', @class, ' '), ' test ')]")
+          set_test_count(testcase_elements.size)
+        end
+
+        def fail_count
+          fail_count_element = REXML::XPath.first(@root, ".//*[@id = 'counters']//*[@id='fail-count']/*[@class = 'number']/text()")
+          return fail_count_element.to_s.to_i if fail_count_element
+          return 0
+        end
+
+        def set_fail_count(fail_count)
+          counters_element = REXML::XPath.first(@root, ".//*[@id = 'counters']")
+          fail_count_number_element = REXML::XPath.first(counters_element, ".//*[@id='fail-count']/*[@class = 'number']/text()")
+          if fail_count_number_element
+            fail_count_number_element.value = fail_count.to_s
+          else
+            test_count_element = REXML::XPath.first(counters_element, ".//*[@id='test-count']")
+            fail_count_element = test_count_element.clone
+            fail_count_element.add_attribute('id', 'fail-count')
+
+            test_count_element.each_element do |element|
+              fail_count_element.add_element(element.clone)
+            end
+            REXML::XPath.first(fail_count_element, ".//*[@class = 'number']").text = fail_count
+            counters_element.add_element(fail_count_element)
+          end
+        end
+
+        def update_fail_count
+          xpath_class_attributes = [
+            "contains(concat(' ', @class, ' '), ' test ')",
+            "contains(concat(' ', @class, ' '), ' failing ')"
+          ].join(' and ')
+
+          failing_testcase_elements = REXML::XPath.match(@root, ".//[#{xpath_class_attributes}]")
+          set_fail_count(failing_testcase_elements.size)
+        end
+
+        def add_test_center_footer
+          test_center_footer = REXML::XPath.first(@root, ".//footer[@id = 'test-center-footer']")
+          return if test_center_footer
+
+          test_center_anchor = REXML::Element.new('a')
+          test_center_anchor.text = 'collate_html_reports'
+          test_center_anchor.add_attribute('href', 'https://github.com/lyndsey-ferguson/fastlane-plugin-test_center#collate_html_reports')
+
+          test_center_footer = REXML::Element.new('footer')
+          test_center_footer.add_attribute('id', 'test-center-footer')
+          test_center_footer.text = 'Collated by the '
+          test_center_footer.add_element(test_center_anchor)
+          test_center_footer.add_text(' action from the test_center fastlane plugin')
+
+          body_element = REXML::XPath.first(@root, "//body")
+          body_element.elements.add(test_center_footer)
+        end
+
+        def save_report(report_path)
+          add_test_center_footer
+
+          output = ''
+          formatter = REXML::Formatters::Transitive.new
+          formatter.write(@root, output)
+
+          File.open(report_path, 'w') do |f|
+            f.puts output
+          end
+        end
+      end
+
+      class TestSuite
+        attr_reader :root
+
+        def initialize(testsuite_element)
+          @root = testsuite_element
+        end
+
+        def title
+          @root.attribute('id').value
+        end
+
+        def testcases
+          testcase_elements = REXML::XPath.match(@root, ".//*[contains(@class, 'tests')]//*[contains(concat(' ', @class, ' '), ' test ')]")
+          testcase_elements.map do |testcase_element|
+            TestCase.new(testcase_element)
+          end
+        end
+
+        def testcase_with_title(title)
+          testcase_element = REXML::XPath.first(@root, ".//*[contains(@class, 'tests')]//*[contains(concat(' ', @class, ' '), ' test ')]//*[@class='title']/[normalize-space()='#{title}']/../../..")
+          TestCase.new(testcase_element) unless testcase_element.nil?
+        end
+
+        def passing?
+          @root.attribute('class').value.include?('passing')
+        end
+
+        def set_passing(status)
+          desired_status = status ? ' passing ' : ' failing '
+          to_replace = status ? /\bfailing\b/ : /\bpassing\b/
+  
+          attribute = @root.attribute('class').value.sub(to_replace, desired_status)
+          attribute.gsub!(/\s{2,}/, ' ')
+          @root.add_attribute('class', attribute)  
+        end
+
+        def add_testcase(testcase)
+          tests_table = REXML::XPath.first(@root, ".//*[contains(@class, 'tests')]/table")
+          details = testcase.failure_details
+          if details
+            tests_table.push(details)
+            tests_table.insert_before(details, testcase.root)
+          else
+            tests_table.push(testcase.root)
+          end
+        end
+
+        def duplicate_testcases?
+          nonuniq_testcases = testcases
+          uniq_testcases = nonuniq_testcases.uniq { |tc| tc.title }
+          nonuniq_testcases != uniq_testcases
+        end
+
+        def remove_duplicate_testcases
+          nonuniq_testcases = testcases
+          uniq_testcases = nonuniq_testcases.uniq { |tc| tc.title }
+          (nonuniq_testcases - uniq_testcases).each do |tc|
+            failure_details = tc.failure_details
+            tc.root.parent.delete_element(failure_details)
+            tc.root.parent.delete_element(tc.root)
+          end
+        end
+
+        def collate_testsuite(testsuite)
+          given_testcases = testsuite.testcases
+          given_testcases.each do |given_testcase|
+            existing_testcase = testcase_with_title(given_testcase.title)
+            if existing_testcase.nil?
+              FastlaneCore::UI.verbose("\t\tadding testcase\n\t\t\t#{given_testcase.root}")
+              unless given_testcase.passing?
+                FastlaneCore::UI.verbose("\t\t\twith failure:\n\t\t\t\t#{given_testcase.failure_details}")
+              end
+              add_testcase(given_testcase)
+            else
+              FastlaneCore::UI.verbose("\t\tupdating testcase\n\t\t\t#{existing_testcase.root}")
+              unless given_testcase.passing?
+                FastlaneCore::UI.verbose("\t\t\twith failure:\n\t\t\t\t#{given_testcase.failure_details}")
+              end
+              existing_testcase.update_testcase(given_testcase)
+            end
+          end
+          set_passing(testcases.all?(&:passing?))
+        end
+      end
+
+      class TestCase
+        attr_reader :root
+
+        def initialize(testcase_element)
+          @root = testcase_element
+        end
+
+        def title
+          REXML::XPath.first(@root, ".//h3[contains(@class, 'title')]/text()").to_s.strip
+        end
+
+        def passing?
+          @root.attribute('class').value.include?('passing')
+        end
+
+        def row_color
+          @root.attribute('class').value.include?('odd') ? 'odd' : ''
+        end
+
+        def set_row_color(row_color)
+          raise 'row_color must either be "odd" or ""' unless ['odd', ''].include?(row_color)
+
+          current_class_attribute = @root.attribute('class').value.sub(/\bodd\b/, '')
+          @root.add_attribute('class', current_class_attribute << ' ' << row_color)
+        end
+
+        def failure_details
+          return nil if @root.attribute('class').value.include?('passing')
+
+          xpath_class_attributes = [
+            "contains(concat(' ', @class, ' '), ' details ')",
+            "contains(concat(' ', @class, ' '), ' failing ')",
+            "contains(concat(' ', @class, ' '), ' #{title} ')"
+          ].join(' and ')
+          
+          REXML::XPath.first(@root.parent, ".//[#{xpath_class_attributes}]")
+        end
+
+        def remove_failure_details
+          details = failure_details
+          return if details.nil?
+          
+          details.parent.delete_element(details)
+        end
+
+        def update_testcase(testcase)
+          color = row_color
+          failure = failure_details
+          if failure.nil? && !passing?
+            FastlaneCore::UI.error("\t\t\t\tupdating failing test case that does not have failure_details")
+          end
+          parent = @root.parent
+
+          failure.parent.delete(failure) unless failure.nil?
+
+          new_failure = testcase.failure_details
+          if new_failure && testcase.passing?
+            FastlaneCore::UI.error("\t\t\t\tswapping passing failing test case that _does_have_ failure_details")
+          end
+
+          parent.replace_child(@root, testcase.root)
+          @root = testcase.root
+          unless new_failure.nil?
+            parent.insert_after(@root, new_failure)
+          end
+          set_row_color(color)
+        end
+      end
+    end
+  end
+end

--- a/spec/collate_html_reports_spec.rb
+++ b/spec/collate_html_reports_spec.rb
@@ -1,7 +1,3 @@
-
-html_report_1 = File.open('./spec/fixtures/report.html')
-html_report_2 = File.open('./spec/fixtures/report-2.html')
-
 def testidentifiers_from_xmlreport(report)
   testable = REXML::XPath.first(report, "//section[@id='test-suites']")
   testsuites = REXML::XPath.match(testable, "section[contains(@class, 'test-suite')]")
@@ -14,122 +10,89 @@ def testidentifiers_from_xmlreport(report)
   testidentifiers
 end
 
-describe Fastlane::Actions::CollateHtmlReportsAction do
-  before(:each) do
-    allow(File).to receive(:exist?).and_call_original
-    allow(File).to receive(:open).and_call_original
-  end
+module Fastlane::Actions
+  
+  html_report_1 = File.open('./spec/fixtures/report.html')
+  html_report_2 = File.open('./spec/fixtures/report-2.html')
 
-  describe 'it handles invalid data' do
-    it 'a failure occurs when non-existent HTML file is specified' do
-      fastfile = "lane :test do
-        collate_html_reports(
-          reports: ['path/to/non_existent_html_report.html'],
-          collated_report: 'path/to/report.html'
+  atomicboy_ui_testsuite_file = File.read('./spec/fixtures/atomicboy_uitestsuite.html')
+  atomicboy_ui_testsuite_file2 = File.read('./spec/fixtures/atomicboy_uitestsuite-2.html')
+  atomicboy_ui_testsuite_file3 = File.read('./spec/fixtures/atomicboy_uitestsuite-3.html') 
+  atomicboy_ui_testsuite_file4 = File.read('./spec/fixtures/atomicboy_uitestsuite-4.html') 
+
+  describe "CollateHtmlReportsAction" do
+    before(:each) do
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:open).and_call_original
+      @atomicboy_ui_testsuite = REXML::Document.new(atomicboy_ui_testsuite_file).root
+      @atomicboy_ui_testsuite2 = REXML::Document.new(atomicboy_ui_testsuite_file2).root
+      @atomicboy_ui_testsuite3 = REXML::Document.new(atomicboy_ui_testsuite_file3).root      
+      @atomicboy_ui_testsuite4 = REXML::Document.new(atomicboy_ui_testsuite_file4).root      
+    end
+
+    describe 'it handles invalid data' do
+      it 'a failure occurs when non-existent HTML file is specified' do
+        fastfile = "lane :test do
+          collate_html_reports(
+            reports: ['path/to/non_existent_html_report.html'],
+            collated_report: 'path/to/report.html'
+          )
+        end"
+        expect { Fastlane::FastFile.new.parse(fastfile).runner.execute(:test) }.to(
+          raise_error(FastlaneCore::Interface::FastlaneError) do |error|
+            expect(error.message).to match("Error: HTML report not found: 'path/to/non_existent_html_report.html'")
+          end
         )
-      end"
-      expect { Fastlane::FastFile.new.parse(fastfile).runner.execute(:test) }.to(
-        raise_error(FastlaneCore::Interface::FastlaneError) do |error|
-          expect(error.message).to match("Error: HTML report not found: 'path/to/non_existent_html_report.html'")
+      end
+    end
+
+    describe 'it handles valid data' do
+      it 'simply copies a :reports value containing one report' do
+        fastfile = "lane :test do
+          collate_html_reports(
+            reports: ['path/to/fake_html_report.html'],
+            collated_report: 'path/to/report.html'
+          )
+        end"
+        allow(File).to receive(:exist?).with('path/to/fake_html_report.html').and_return(true)
+        allow(File).to receive(:open).with('path/to/fake_html_report.html').and_yield(File.open('./spec/fixtures/report.html'))
+        expect(FileUtils).to receive(:cp).with('path/to/fake_html_report.html', 'path/to/report.html')
+        Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
+      end
+    end
+
+    describe 'it handles malformed data' do
+      it 'fixes and merges malformed html files' do
+        malformed_report = File.open('./spec/fixtures/malformed-report.html')
+        allow(File).to receive(:exist?).with('path/to/fake_html_report_1.html').and_return(true)
+        allow(File).to receive(:new).with('path/to/fake_html_report_1.html').and_return(html_report_1)
+        allow(File).to receive(:exist?).with('path/to/malformed-report.html').and_return(true)
+
+        second_reports = [
+          malformed_report,
+          html_report_1
+        ]
+        allow(File).to receive(:new).with('path/to/malformed-report.html') do
+          second_reports.shift
         end
-      )
-    end
-  end
 
-  describe 'it handles valid data' do
-    it 'simply copies a :reports value containing one report' do
-      fastfile = "lane :test do
-        collate_html_reports(
-          reports: ['path/to/fake_html_report.html'],
-          collated_report: 'path/to/report.html'
+        allow(Fastlane::Actions::CollateHtmlReportsAction).to receive(:repair_malformed_html).with('path/to/malformed-report.html')
+        Fastlane::Actions::CollateHtmlReportsAction.opened_reports(
+          [
+            'path/to/fake_html_report_1.html',
+            'path/to/malformed-report.html'
+          ]
         )
-      end"
-      allow(File).to receive(:exist?).with('path/to/fake_html_report.html').and_return(true)
-      allow(File).to receive(:open).with('path/to/fake_html_report.html').and_yield(File.open('./spec/fixtures/report.html'))
-      expect(FileUtils).to receive(:cp).with('path/to/fake_html_report.html', 'path/to/report.html')
-      Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
-    end
-
-    it 'merges missing testsuites into one file' do
-      fastfile = "lane :test do
-        collate_html_reports(
-          reports: ['path/to/fake_html_report_1.html', 'path/to/fake_html_report_2.html'],
-          collated_report: 'path/to/report.html'
-        )
-      end"
-
-      allow(File).to receive(:exist?).with('path/to/fake_html_report_1.html').and_return(true)
-      allow(File).to receive(:new).with('path/to/fake_html_report_1.html').and_return(html_report_1)
-      allow(File).to receive(:exist?).with('path/to/fake_html_report_2.html').and_return(true)
-      allow(File).to receive(:new).with('path/to/fake_html_report_2.html').and_return(html_report_2)
-      allow(FileUtils).to receive(:mkdir_p)
-
-      report_file = StringIO.new
-      expect(File).to receive(:open).with('path/to/report.html', 'w').and_yield(report_file)
-
-      Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
-      report = REXML::Document.new(report_file.string)
-      actual_test_identifiers = testidentifiers_from_xmlreport(report)
-      expect(actual_test_identifiers).to contain_exactly(
-        'AtomicBoyUITests/testExample',
-        'AtomicBoyUITests/testExample2',
-        'AtomicBoyUITests.SwiftAtomicBoyUITests/testExample'
-      )
-      failing_testcases = REXML::XPath.match(report, ".//*[contains(@class, 'tests')]//*[contains(@class, 'test') and contains(@class, 'failing')]//*[contains(@class, 'title')]")
-      expect(failing_testcases.size).to eq(1)
-      failing_testcase = failing_testcases.first
-      failing_testclass = REXML::XPath.match(failing_testcase, "ancestor::*/*[contains(@class, 'test-suite')]")[0]
-      expect(failing_testclass.attribute('id').value).to eq('AtomicBoyUITests')
-      expect(failing_testcase.text.strip).to eq('testExample')
-
-      failing_testcase_details = REXML::XPath.match(report, ".//*[contains(@class, 'tests')]//*[contains(@class, 'details') and contains(@class, 'failing')]")
-      expect(failing_testcase_details.size).to eq(1)
-      failing_testcase_class = failing_testcase_details[0].attribute('class').value
-      expect(failing_testcase_class.split(' ')).to include('testExample')
-
-      test_count = REXML::XPath.first(report, ".//*[@id='test-count']/span").text.strip
-      expect(test_count).to eq('3')
-      fail_count = REXML::XPath.first(report, ".//*[@id='fail-count']/span").text.strip
-      expect(fail_count).to eq('1')
-
-      failing_testsuites = REXML::XPath.match(report, "//*[contains(@class, 'test-suite') and contains(@class, 'failing')]")
-      expect(failing_testsuites.size).to eq(1)
-      passing_testsuites = REXML::XPath.match(report, "//*[contains(@class, 'test-suite') and contains(@class, 'passing')]")
-      expect(passing_testsuites.size).to eq(1)
-    end
-  end
-
-  describe 'it handles malformed data' do
-    it 'fixes and merges malformed html files' do
-      malformed_report = File.open('./spec/fixtures/malformed-report.html')
-      allow(File).to receive(:exist?).with('path/to/fake_html_report_1.html').and_return(true)
-      allow(File).to receive(:new).with('path/to/fake_html_report_1.html').and_return(html_report_1)
-      allow(File).to receive(:exist?).with('path/to/malformed-report.html').and_return(true)
-
-      second_reports = [
-        malformed_report,
-        html_report_1
-      ]
-      allow(File).to receive(:new).with('path/to/malformed-report.html') do
-        second_reports.shift
       end
 
-      expect(Fastlane::Actions::CollateHtmlReportsAction).to receive(:repair_malformed_html).with('path/to/malformed-report.html')
-      Fastlane::Actions::CollateHtmlReportsAction.opened_reports(
-        [
-          'path/to/fake_html_report_1.html',
-          'path/to/malformed-report.html'
-        ]
-      )
-    end
-
-    it 'finds and fixes unescaped less-than or greater-than characters' do
-      malformed_report = File.open('./spec/fixtures/malformed-report.html')
-      allow(File).to receive(:read).with('path/to/malformed-report.html').and_return(malformed_report.read)
-      patched_file = StringIO.new
-      allow(File).to receive(:open).with('path/to/malformed-report.html', 'w').and_yield(patched_file)
-      Fastlane::Actions::CollateHtmlReportsAction.repair_malformed_html('path/to/malformed-report.html')
-      expect(patched_file.string).to include('&lt;unknown&gt;')
+      it 'finds and fixes unescaped less-than or greater-than characters' do
+        malformed_report = File.open('./spec/fixtures/malformed-report.html')
+        allow(File).to receive(:read).with('path/to/malformed-report.html').and_return(malformed_report.read)
+        patched_file = StringIO.new
+        allow(File).to receive(:open).with('path/to/malformed-report.html', 'w').and_yield(patched_file)
+        Fastlane::Actions::CollateHtmlReportsAction.repair_malformed_html('path/to/malformed-report.html')
+        expect(patched_file.string).to include('&lt;unknown&gt;')
+      end
     end
   end
 end

--- a/spec/fixtures/atomicboy_uitestsuite-2.html
+++ b/spec/fixtures/atomicboy_uitestsuite-2.html
@@ -1,0 +1,19 @@
+<section class="test-suite passing" id="AtomicBoyUITests">
+  <section class="heading" onclick="toggleTests(this);">
+    <h3 class="title">AtomicBoyUITests</h3>
+  </section>
+  <section class="tests">
+    <table>
+    
+      
+      <tr class="test passing "  onclick="toggleDetails('testExample17');">
+        <td>
+          
+            <h3 class="time">5.534s</h3>
+          
+        </td>
+        <td><h3 class="title">testExample17</h3></td>
+      </tr>
+    </table>
+  </section>
+</section>

--- a/spec/fixtures/atomicboy_uitestsuite-3.html
+++ b/spec/fixtures/atomicboy_uitestsuite-3.html
@@ -1,0 +1,19 @@
+<section class="test-suite passing" id="AtomicBoyUITests">
+  <section class="heading" onclick="toggleTests(this);">
+    <h3 class="title">AtomicBoyUITests</h3>
+  </section>
+  <section class="tests">
+    <table>
+    
+      
+      <tr class="test passing "  onclick="toggleDetails('testExample99');">
+        <td>
+          
+            <h3 class="time">5.534s</h3>
+          
+        </td>
+        <td><h3 class="title">testExample99</h3></td>
+      </tr>
+    </table>
+  </section>
+</section>

--- a/spec/fixtures/atomicboy_uitestsuite-4.html
+++ b/spec/fixtures/atomicboy_uitestsuite-4.html
@@ -1,0 +1,32 @@
+<section class="test-suite passing" id="AtomicBoyUITests">
+  <section class="heading" onclick="toggleTests(this);">
+    <h3 class="title">AtomicBoyUITests</h3>
+  </section>
+  <section class="tests">
+    <table>
+    
+      
+      <tr class="test failing "  onclick="toggleDetails('testExample99');">
+        <td>
+          
+            <h3 class="time">5.534s</h3>
+          
+        </td>
+        <td><h3 class="title">testExample99</h3></td>
+      </tr>
+      <tr class="details failing testExample99">
+        <td></td>
+        <td>
+
+          <section class="test-detail reason">((false) is true) failed</section>
+
+
+          <section class="test-detail snippet"></section>
+          <section class="test-detail">AtomicBoyUITests.m:168</section>
+
+
+        </td>
+      </tr>
+    </table>
+  </section>
+</section>

--- a/spec/fixtures/atomicboy_uitestsuite.html
+++ b/spec/fixtures/atomicboy_uitestsuite.html
@@ -1,0 +1,59 @@
+<section class="test-suite failing" id="AtomicBoyUITests">
+  <section class="heading" onclick="toggleTests(this);">
+    <h3 class="title">AtomicBoyUITests</h3>
+  </section>
+  <section class="tests">
+    <table>
+
+
+      <tr class="test failing " onclick="toggleDetails('testExample17');">
+        <td></td>
+        <td>
+          <h3 class="title">testExample17</h3>
+        </td>
+      </tr>
+      <tr class="details failing testExample17">
+        <td></td>
+        <td>
+
+          <section class="test-detail reason">((false) is true) failed</section>
+
+
+          <section class="test-detail snippet"></section>
+          <section class="test-detail">AtomicBoyUITests.m:168</section>
+
+
+        </td>
+      </tr>
+
+
+      <tr class="test passing odd" onclick="toggleDetails('testExample2');">
+        <td>
+
+          <h3 class="time">5.528s</h3>
+
+        </td>
+        <td>
+          <h3 class="title">
+            testExample2
+          </h3>
+        </td>
+      </tr>
+
+
+
+      <tr class="test passing " onclick="toggleDetails('testExample5');">
+        <td>
+
+          <h3 class="time">5.921s</h3>
+
+        </td>
+        <td>
+          <h3 class="title">testExample5</h3>
+        </td>
+      </tr>
+
+
+    </table>
+  </section>
+</section>

--- a/spec/fixtures/report-2.html
+++ b/spec/fixtures/report-2.html
@@ -121,54 +121,6 @@
       </section>
     </header>
     <section id="test-suites">
-      
-        
-        <section class="test-suite failing" id="AtomicBoyUITests">
-          <section class="heading" onclick="toggleTests(this);">
-            <h3 class="title">AtomicBoyUITests</h3>
-          </section>
-          <section class="tests">
-            <table>
-            
-              
-              <tr class="test failing "  onclick="toggleDetails('testExample');">
-                <td>
-                  
-                </td>
-                <td><h3 class="title">testExample</h3></td>
-              </tr>
-              
-                <tr class="details failing testExample">
-                  <td></td>
-                  <td>
-                    
-                      <section class="test-detail reason">((false) is true) failed</section>
-                    
-                    
-                      <section class="test-detail snippet"></section>
-                      <section class="test-detail">AtomicBoyUITests.m:40</section>
-                    
-                    
-                  </td>
-                </tr>
-              
-            
-              
-              <tr class="test passing odd"  onclick="toggleDetails('testExample2');">
-                <td>
-                  
-                    <h3 class="time">4.753s</h3>
-                  
-                </td>
-                <td><h3 class="title">testExample2</h3></td>
-              </tr>
-              
-            
-            </table>
-          </section>
-        </section>
-      
-        
         <section class="test-suite passing" id="AtomicBoyUITests.SwiftAtomicBoyUITests">
           <section class="heading" onclick="toggleTests(this);">
             <h3 class="title">AtomicBoyUITests.SwiftAtomicBoyUITests</h3>

--- a/spec/fixtures/report-4.html
+++ b/spec/fixtures/report-4.html
@@ -110,9 +110,9 @@
       </section>
       <section class="right">
         <section id="counters">
-          <h2 id="test-count"><span class="number">3</span> tests</h2>
+          <h2 id="test-count"><span class="number">1</span> tests</h2>
           
-          <h2 id="fail-count"><span class="number">3</span> failures</h2>
+            <h2 id="fail-count"><span class="number">1</span> failures</h2>
           
         </section>
         <section id="segment-bar">
@@ -123,7 +123,7 @@
     <section id="test-suites">
       
         
-        <section class="test-suite failing" id="AtomicBoyUITests">
+        <section class="test-suite passing" id="BasketballTests">
           <section class="heading" onclick="toggleTests(this);">
             <h3 class="title">AtomicBoyUITests</h3>
           </section>
@@ -131,86 +131,12 @@
             <table>
             
               
-              <tr class="test failing "  onclick="toggleDetails('testExample');">
+              <tr class="test passing "  onclick="toggleDetails('testNetStrengthMeetsStandards');">
                 <td>
                   
                 </td>
-                <td><h3 class="title">testExample</h3></td>
-              </tr>
-              
-                <tr class="details failing testExample">
-                  <td></td>
-                  <td>
-                    
-                      <section class="test-detail reason">((false) is true) failed</section>
-                    
-                    
-                      <section class="test-detail snippet"></section>
-                      <section class="test-detail">AtomicBoyUITests.m:40</section>
-                    
-                    
-                  </td>
-                </tr>
-              
-            
-              
-              <tr class="test failing odd"  onclick="toggleDetails('testExample2');">
-                <td>
-                  
-                </td>
-                <td><h3 class="title">testExample2</h3></td>
-              </tr>
-              
-                <tr class="details failing testExample2">
-                  <td></td>
-                  <td>
-                    
-                      <section class="test-detail reason">((false) is true) failed</section>
-                    
-                    
-                      <section class="test-detail snippet"></section>
-                      <section class="test-detail">AtomicBoyUITests.m:48</section>
-                    
-                    
-                  </td>
-                </tr>
-              
-            
-            </table>
-          </section>
-        </section>
-      
-        
-        <section class="test-suite failing" id="AtomicBoyUITests.SwiftAtomicBoyUITests">
-          <section class="heading" onclick="toggleTests(this);">
-            <h3 class="title">AtomicBoyUITests.SwiftAtomicBoyUITests</h3>
-          </section>
-          <section class="tests">
-            <table>
-            
-              
-              <tr class="test failing "  onclick="toggleDetails('testExample');">
-                <td>
-                  
-                </td>
-                <td><h3 class="title">testExample</h3></td>
-              </tr>
-              
-                <tr class="details failing testExample">
-                  <td></td>
-                  <td>
-                    
-                      <section class="test-detail reason">XCTAssertTrue failed - </section>
-                    
-                    
-                      <section class="test-detail snippet"></section>
-                      <section class="test-detail">SwiftAtomicBoyUITests.swift:14</section>
-                    
-                    
-                  </td>
-                </tr>
-              
-            
+                <td><h3 class="title">testNetStrengthMeetsStandards</h3></td>
+              </tr>            
             </table>
           </section>
         </section>

--- a/spec/fixtures/report-5.html
+++ b/spec/fixtures/report-5.html
@@ -110,9 +110,9 @@
       </section>
       <section class="right">
         <section id="counters">
-          <h2 id="test-count"><span class="number">3</span> tests</h2>
+          <h2 id="test-count"><span class="number">4</span> tests</h2>
           
-          <h2 id="fail-count"><span class="number">3</span> failures</h2>
+          <h2 id="fail-count"><span class="number">4</span> failures</h2>
           
         </section>
         <section id="segment-bar">
@@ -130,7 +130,27 @@
           <section class="tests">
             <table>
             
+              <tr class="test failing odd"  onclick="toggleDetails('testExample2');">
+                <td>
+                  
+                </td>
+                <td><h3 class="title">testExample2</h3></td>
+              </tr>
               
+                <tr class="details failing testExample2">
+                  <td></td>
+                  <td>
+                    
+                      <section class="test-detail reason">((false) is true) failed</section>
+                    
+                    
+                      <section class="test-detail snippet"></section>
+                      <section class="test-detail">AtomicBoyUITests.m:48</section>
+                    
+                    
+                  </td>
+                </tr>
+
               <tr class="test failing "  onclick="toggleDetails('testExample');">
                 <td>
                   
@@ -154,14 +174,14 @@
               
             
               
-              <tr class="test failing odd"  onclick="toggleDetails('testExample2');">
+              <tr class="test failing odd"  onclick="toggleDetails('testExample');">
                 <td>
                   
                 </td>
-                <td><h3 class="title">testExample2</h3></td>
+                <td><h3 class="title">testExample</h3></td>
               </tr>
               
-                <tr class="details failing testExample2">
+                <tr class="details failing testExample">
                   <td></td>
                   <td>
                     

--- a/spec/html_test_report_spec.rb
+++ b/spec/html_test_report_spec.rb
@@ -1,0 +1,426 @@
+module TestCenter::Helper::HtmlTestReport
+  describe 'HtmlTestReport' do
+    describe 'Report' do
+      describe '#testsuites' do
+        it 'returns the correct number of testsuites' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          expect(testsuites.size).to eq(2)
+        end
+      end
+
+      describe '#testsuite_with_title' do
+        it 'finds the given testsuite when it exists' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          atomic_boy_ui_testsuite = html_report.testsuite_with_title('AtomicBoyUITests')
+          expect(atomic_boy_ui_testsuite).not_to eq(nil)
+          expect(atomic_boy_ui_testsuite.passing?).to eq(false)
+        end
+
+        it 'returns nil when the given testsuite does not exist' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          non_existent_testsuite = html_report.testsuite_with_title('Nihil')
+          expect(non_existent_testsuite).to eq(nil)
+        end
+      end
+
+      describe '#add_testsuite' do
+        it 'adds the given testsuite' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          html_report4 = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-4.html'))))
+          new_testsuite = html_report4.testsuites[0]
+          html_report.add_testsuite(new_testsuite)
+          expect(html_report.testsuites.size).to eq(3)
+        end
+      end
+
+      describe '#test_count' do
+        it 'returns the correct number of tests' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          expect(html_report.test_count).to eq(3)
+        end
+      end
+
+      describe '#set_test_count' do
+        it 'updtes the test count correctly' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          html_report.set_test_count(97)
+          expect(html_report.test_count).to eq(97)
+        end
+      end
+      
+      describe '#fail_count' do
+        it 'returns the correct number of tests' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          expect(html_report.fail_count).to eq(3)
+        end
+      end
+
+      describe '#set_fail_count' do
+        it 'returns the correct number of tests' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          html_report.set_fail_count(45)
+          expect(html_report.fail_count).to eq(45)
+        end
+      end
+
+      describe '#collate_report' do
+        it 'merges the given reports with only existing testsuites' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+
+          html_report2 = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-2.html'))))
+          html_report.collate_report(html_report2)
+          expect(html_report.testsuites.map(&:passing?)).to eq([false, true])
+          failing_testcase_details = REXML::XPath.match(html_report.root, ".//*[contains(@class, 'tests')]//*[contains(@class, 'details') and contains(@class, 'failing')]")
+          expect(failing_testcase_details.size).to eq(2)
+        end
+
+        it 'adds the given testsuite to the report when it didn\'t previously exist' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+
+          html_report4 = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-4.html'))))
+          html_report.collate_report(html_report4)
+          expect(html_report.testsuites.map(&:passing?)).to eq([false, false, true])
+        end
+
+        it 'updates the test-count' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+
+          html_report4 = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-4.html'))))
+          html_report.collate_report(html_report4)
+          expect(html_report.test_count).to eq(4)
+        end
+
+        it 'updates the fail-count' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+
+          html_report2 = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-2.html'))))
+          html_report.collate_report(html_report2)
+          expect(html_report.fail_count).to eq(2)
+        end
+      end
+
+      describe '#save_report' do
+        it 'saves a collated report' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+  
+          html_report2 = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-2.html'))))
+          html_report.collate_report(html_report2)
+  
+          report_file = StringIO.new
+          expect(File).to receive(:open).with('path/to/report.html', 'w').and_yield(report_file)
+  
+          html_report.save_report('path/to/report.html')
+          written_html_report = Report.new(REXML::Document.new(report_file.string))
+          expect(written_html_report.testsuites.map(&:passing?)).to eq([false, true])
+        end
+      end
+    end
+
+    describe 'TestSuite' do
+      describe '#title' do
+        it 'returns the correct title' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          expect(testsuites[0].title).to eq("AtomicBoyUITests")
+          expect(testsuites[1].title).to eq("AtomicBoyUITests.SwiftAtomicBoyUITests")
+        end
+      end
+
+      describe '#testcases' do
+        it 'returns the correct number of testcases' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcases = testsuites[0].testcases
+          expect(atomic_boy_ui_testcases.size).to eq(2)
+          atomic_boy_ui_swift_testcases = testsuites[1].testcases
+          expect(atomic_boy_ui_swift_testcases.size).to eq(1)
+        end
+      end
+
+      describe '#passing?' do
+        it 'returns true when all testcases have passed' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite-2.html'))))
+          atomic_boy_testsuite = html_report.testsuites[0]
+          expect(atomic_boy_testsuite.passing?).to eq(true)
+        end
+
+        it 'returns false when not all testcases have passed' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_testsuite = html_report.testsuites[0]
+          expect(atomic_boy_testsuite.passing?).to eq(false)
+        end
+      end
+
+      describe '#set_passing' do
+        it 'sets failing testsuite to passing' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_testsuite = html_report.testsuites[0]
+          atomic_boy_testsuite.set_passing(true)
+          expect(atomic_boy_testsuite.passing?).to eq(true)
+        end
+
+        it 'sets passing testsuite to failing' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite-2.html'))))
+          atomic_boy_testsuite = html_report.testsuites[0]
+          atomic_boy_testsuite.set_passing(false)
+          expect(atomic_boy_testsuite.passing?).to eq(false)
+        end
+      end
+
+      describe '#testcase_with_title' do
+        it 'returns an existing testcase that has the given title' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_testsuite = html_report.testsuites[0]
+          testcase = atomic_boy_testsuite.testcase_with_title('testExample2')
+          expect(testcase).not_to be(nil)
+          expect(testcase.row_color).to eq('odd')
+          expect(testcase.passing?).to eq(true)
+        end
+
+        it 'returns nil for a testcase that does not exist in the testsuite' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_testsuite = html_report.testsuites[0]
+          testcase = atomic_boy_testsuite.testcase_with_title('testExample98')
+          expect(testcase).to be(nil)
+        end
+      end
+
+      describe '#add_testcase' do
+        it 'adds the given testcase' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_testsuite = html_report.testsuites[0]
+
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite-4.html'))))
+          testcase_99 = html_report.testsuites[0].testcase_with_title('testExample99')
+          atomic_boy_testsuite.add_testcase(testcase_99)
+          testcases = atomic_boy_testsuite.testcases
+          expect(testcases.size).to eq(4)
+          expect(atomic_boy_testsuite.testcase_with_title('testExample99')).not_to be(nil)
+        end
+      end
+
+      describe '#remove_duplicate_testcases' do
+        it 'removes duplicate testscases' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-5.html'))))
+          testsuite_1 = html_report.testsuites[0]
+          testsuite_1.remove_duplicate_testcases
+          testcases_titles = testsuite_1.testcases.map(&:title)
+          expect(testcases_titles).to eq(["testExample2", "testExample"])
+        end
+      end
+
+      describe '#collate_testsuite' do
+        it 'replaces failing testcases with passing testcases' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_failing_testsuite = html_report.testsuites[0]
+
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite-2.html'))))
+          atomic_boy_passing_testsuite = html_report.testsuites[0]
+
+          atomic_boy_failing_testsuite.collate_testsuite(atomic_boy_passing_testsuite)
+          testcases = atomic_boy_failing_testsuite.testcases
+          passing_statuses = testcases.map(&:passing?)
+          expect(passing_statuses).to eq(
+            [
+              true,
+              true,
+              true
+            ]
+          )
+        end
+
+        it 'adds new testcases to testsuite' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_failing_testsuite = html_report.testsuites[0]
+
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite-4.html'))))
+          atomic_boy_passing_testsuite = html_report.testsuites[0]
+          atomic_boy_failing_testsuite.collate_testsuite(atomic_boy_passing_testsuite)
+          testcases = atomic_boy_failing_testsuite.testcases
+          passing_statuses = testcases.map(&:passing?)
+          expect(passing_statuses).to eq(
+            [
+              false,
+              true,
+              true,
+              false
+            ]
+          )
+        end
+
+        it 'updates the testsuite\'s passing status' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_failing_testsuite = html_report.testsuites[0]
+
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite-2.html'))))
+          atomic_boy_passing_testsuite = html_report.testsuites[0]
+
+          atomic_boy_failing_testsuite.collate_testsuite(atomic_boy_passing_testsuite)
+          expect(atomic_boy_failing_testsuite.passing?).to eq(true)
+        end
+
+        it 'updates the testsuite\'s failing status' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite-2.html'))))
+          atomic_boy_passing_testsuite = html_report.testsuites[0]
+
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          atomic_boy_failing_testsuite = html_report.testsuites[0]
+
+          atomic_boy_passing_testsuite.collate_testsuite(atomic_boy_failing_testsuite)
+          expect(atomic_boy_failing_testsuite.passing?).to eq(false)
+        end
+      end
+    end
+
+    describe 'TestCase' do
+      describe '#title' do
+        it 'returns the correct title' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcases = testsuites[0].testcases
+          testcases_titles = atomic_boy_ui_testcases.map(&:title)
+          expect(testcases_titles).to eq(
+            [
+              "testExample",
+              "testExample2"
+            ]
+          )
+        end
+      end
+
+      describe '#row_color' do
+        it 'returns the correct row colors' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcases = testsuites[0].testcases
+          testcase_row_colors = atomic_boy_ui_testcases.map(&:row_color)
+          expect(testcase_row_colors).to eq(
+            [
+              '',
+              'odd'
+            ]
+          )
+        end
+      end
+
+      describe '#passing?' do
+        it 'returns true when testcase is passing' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/atomicboy_uitestsuite.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcases = testsuites[0].testcases
+          passing_statuses = atomic_boy_ui_testcases.map(&:passing?)
+          expect(passing_statuses).to eq(
+            [
+              false,
+              true,
+              true
+            ]
+          )
+        end
+      end
+
+      describe '#set_row_color' do
+        it 'correctly sets an even row_color' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcase2 = testsuites[0].testcases[1]
+          atomic_boy_ui_testcase2.set_row_color('')
+          expect(atomic_boy_ui_testcase2.row_color).to eq('')
+        end
+
+        it 'correctly sets an odd row_color' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcase1 = testsuites[0].testcases[0]
+          atomic_boy_ui_testcase1.set_row_color('odd')
+          expect(atomic_boy_ui_testcase1.row_color).to eq('odd')
+        end
+
+        it 'throws an error if set to an invalid color' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcase1 = testsuites[0].testcases[0]
+          expect { atomic_boy_ui_testcase1.set_row_color('invalid') }
+            .to raise_error('row_color must either be "odd" or ""')
+        end
+      end
+
+      describe '#failure_details' do
+        it 'returns an empty string for a passing testcase' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-2.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_swift_testcase1 = testsuites[0].testcases[0]
+          expect(atomic_boy_ui_swift_testcase1.failure_details).to be_nil
+        end
+
+        it 'returns the failure details for a failing test' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcase1 = testsuites[0].testcases[0]
+          failure_details = atomic_boy_ui_testcase1.failure_details
+          failure_reason = REXML::XPath.first(failure_details, "//[contains(@class, 'reason')]/text()").to_s
+          expect(failure_reason).to eq('((false) is true) failed')
+          failure_location = REXML::XPath.first(failure_details, "//[@class = 'test-detail']/text()").to_s
+          expect(failure_location).to eq('AtomicBoyUITests.m:40')
+        end
+      end
+      
+      describe '#remove_failure_details' do
+        it 'removes the failure details from the testcase' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_testcase1 = testsuites[0].testcases[0]
+          atomic_boy_ui_testcase1.remove_failure_details
+          expect(atomic_boy_ui_testcase1.failure_details).to be(nil)
+        end
+      end
+
+      describe '#update_testcase' do
+        it 'replaces a failing testcase with a passing test case' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_failing_testcase = testsuites[1].testcases[0]
+
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-2.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_swift_passing_testcase = testsuites[0].testcases[0]
+
+          atomic_boy_ui_failing_testcase.update_testcase(atomic_boy_ui_swift_passing_testcase)
+          expect(atomic_boy_ui_failing_testcase.failure_details).to be_nil
+        end
+
+        it 'replaces a passing test case with a failing test case' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_failing_testcase = testsuites[1].testcases[0]
+
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-2.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_swift_passing_testcase = testsuites[0].testcases[0]
+
+          atomic_boy_ui_swift_passing_testcase.update_testcase(atomic_boy_ui_failing_testcase)
+          failure_details = atomic_boy_ui_swift_passing_testcase.failure_details
+          failure_reason = REXML::XPath.first(failure_details, "//[contains(@class, 'reason')]/text()").to_s
+          expect(failure_reason).to eq('XCTAssertTrue failed - ')
+          failure_location = REXML::XPath.first(failure_details, "//[@class = 'test-detail']/text()").to_s
+          expect(failure_location).to eq('SwiftAtomicBoyUITests.swift:14')
+        end
+
+        it 'matches the previous row color' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_failing_testcase = testsuites[1].testcases[0]
+          atomic_boy_ui_failing_testcase.set_row_color('odd')
+          
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-2.html'))))
+          testsuites = html_report.testsuites
+          atomic_boy_ui_swift_passing_testcase = testsuites[0].testcases[0]
+
+          atomic_boy_ui_failing_testcase.update_testcase(atomic_boy_ui_swift_passing_testcase)
+          expect(atomic_boy_ui_failing_testcase.row_color).to eq('odd')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Resolves #126.

There are two known problems with the collation of HTML reports:
1. collated tests are placed outside of the `<table/>` and this breaks the formatting of the HTML page.
2. collated tests do not properly alternate background colors per row.

### Description
<!-- Describe your changes in detail -->

- Add smaller, more exact functions for getting information from testsuites, testcases
- Add smaller functions for merging testcases into testsuites

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md