### PR TITLE
issue-136 better test for identical file for report collating

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
@@ -57,7 +57,7 @@ module TestCenter
             )
             CollateJunitReportsAction.run(config)
             FileUtils.rm_rf(report_files - [collated_file])
-          elsif report_files.size == 1 && report_files.first != collated_file
+          elsif report_files.size == 1 && ! File.identical?(report_files.first, collated_file)
             FastlaneCore::UI.verbose("Copying junit report file #{report_files.first}")
             FileUtils.mkdir_p(File.dirname(collated_file))
             FileUtils.mv(report_files.first, collated_file)
@@ -80,7 +80,7 @@ module TestCenter
             )
             CollateHtmlReportsAction.run(config)
             FileUtils.rm_rf(report_files - [collated_file])
-          elsif report_files.size == 1 && report_files.first != collated_file
+          elsif report_files.size == 1 && ! File.identical?(report_files.first, collated_file)
             FastlaneCore::UI.verbose("Copying html report file #{report_files.first}")
             FileUtils.mkdir_p(File.dirname(collated_file))
             FileUtils.mv(report_files.first, collated_file)
@@ -103,7 +103,7 @@ module TestCenter
             )
             CollateJsonReportsAction.run(config)
             FileUtils.rm_rf(report_files - [collated_file])
-          elsif report_files.size == 1 && report_files.first != collated_file
+          elsif report_files.size == 1 && ! File.identical?(report_files.first, collated_file)
             FastlaneCore::UI.verbose("Copying json report file #{report_files.first}")
             FileUtils.mkdir_p(File.dirname(collated_file))
             FileUtils.mv(report_files.first, collated_file)
@@ -126,7 +126,7 @@ module TestCenter
             )
             CollateTestResultBundlesAction.run(config)
             FileUtils.rm_rf(test_result_bundlepaths - [collated_test_result_bundlepath])
-          elsif test_result_bundlepaths.size == 1 && test_result_bundlepaths.first != collated_test_result_bundlepath
+          elsif test_result_bundlepaths.size == 1 && File.realdirpath(test_result_bundlepaths.first) != File.realdirpath(collated_test_result_bundlepath)
             FastlaneCore::UI.verbose("Copying test_result bundle #{test_result_bundlepaths.first}")
             FileUtils.mkdir_p(File.dirname(collated_test_result_bundlepath))
             FileUtils.mv(test_result_bundlepaths.first, collated_test_result_bundlepath)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Addresses crashing issue #136 where collation of single files would fail if, via some mechanism, the file being moved is the same, but a string comparison of absolute paths yields that they are not the same file.

I tested via `rake` and running `multi_scan` on the sample project with `result bundles` and `html` and `junit` report files. With no batches and a try count of 1.

### Description
<!-- Describe your changes in detail -->

Use `File.identical?` for file comparison when moving the 1 report file to the final file. Use `File.realdirpath` to get the real path of test result directories.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md