### PR TITLE
issue-142 remove build-for-testing from xcargs

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
@@ -30,8 +30,13 @@ module TestCenter
                                   .merge(@retrying_scan_helper.scan_options)
 
           prepare_scan_config_for_destination
+          scan_options[:build_for_testing] = false
+          FastlaneCore::UI.verbose("retrying_scan #update_scan_options")
           scan_options.each do |k,v|
+            next if v.nil?
+ 
             scan_config.set(k,v) unless v.nil?
+            FastlaneCore::UI.verbose("\tSetting #{k.to_s} to #{v}")
           end
         end
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -81,6 +81,10 @@ module TestCenter
         def scan_options
           valid_scan_keys = Fastlane::Actions::ScanAction.available_options.map(&:key)
           xcargs = @options[:xcargs]
+          if xcargs&.include?('build-for-testing')
+            FastlaneCore::UI.verbose(":xcargs, #{xcargs}, contained 'build-for-testing', removing it")
+            xcargs.slice!('build-for-testing')
+          end
           retrying_scan_options = @reportnamer.scan_options.merge(
             {
               output_directory: output_directory,
@@ -153,8 +157,8 @@ module TestCenter
           junit_results, report_filepath = failure_details(additional_info)
 
           info = {
-            failed: junit_results[:failed],
-            passing: junit_results[:passing],
+            failed: junit_results.fetch(:failed, []),
+            passing: junit_results.fetch(:passing, []),
             batch: @options[:batch] || 1,
             try_count: @testrun_count,
             report_filepath: report_filepath

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -82,7 +82,7 @@ module TestCenter
           valid_scan_keys = Fastlane::Actions::ScanAction.available_options.map(&:key)
           xcargs = @options[:xcargs]
           if xcargs&.include?('build-for-testing')
-            FastlaneCore::UI.verbose(":xcargs, #{xcargs}, contained 'build-for-testing', removing it")
+            FastlaneCore::UI.important(":xcargs, #{xcargs}, contained 'build-for-testing', removing it")
             xcargs.slice!('build-for-testing')
           end
           retrying_scan_options = @reportnamer.scan_options.merge(

--- a/spec/multi_scan_manager/retrying_scan_helper_spec.rb
+++ b/spec/multi_scan_manager/retrying_scan_helper_spec.rb
@@ -623,8 +623,8 @@ module TestCenter::Helper::MultiScanManager
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneBuildFailure.new('test failure'))
         expect(actual_testrun_info).to include(
-          failed: nil,
-          passing: nil,
+          failed: [],
+          passing: [],
           test_operation_failure: 'Test runner exited before starting test execution',
           batch: 1,
           try_count: 1,
@@ -660,8 +660,8 @@ module TestCenter::Helper::MultiScanManager
           end
         )
         expect(actual_testrun_info).to include(
-          failed: nil,
-          passing: nil,
+          failed: [],
+          passing: [],
           test_operation_failure: 'Launch session expired before checking in',
           batch: 1,
           try_count: 1,


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes a number of issues brought up in #142: 
- calling `:testrun_completed_block` when `xcodebuild` fails and no junit report file is created can inadvertently cause a crash.
- clients can pass `build-for-testing` in xcargs, which, when combined with running scan with 'test-without-building', will cause `xcodebuild` to crash.

### Description
<!-- Describe your changes in detail -->

1. Provide either failing tests or an empty array to the `testrun_completed_block` callback for both failing and passing tests.
2. Explicitly remove `build-for-testing` from `xcargs`

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md