### PR TITLE
Issue 145 crash when collating test bundles

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
@@ -114,7 +114,10 @@ module TestCenter
           return unless @result_bundle
 
           test_result_bundlepaths = sort_globbed_files("#{@source_reports_directory_glob}/#{@scheme}*.test_result")
-          collated_test_result_bundlepath = File.absolute_path("#{File.join(@output_directory, @scheme)}.test_result")
+          result_bundlename_suffix = ''
+          result_bundlename_suffix = "-#{@reportnamer.report_count + 1}" if @reportnamer.report_count > 0
+
+          collated_test_result_bundlepath = File.absolute_path("#{File.join(@output_directory, @scheme)}#{result_bundlename_suffix}.test_result")
           if test_result_bundlepaths.size > 1
             FastlaneCore::UI.verbose("Collating test_result bundles #{test_result_bundlepaths}")
             config = create_config(

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -40,6 +40,9 @@ module TestCenter
         def delete_xcresults
           derived_data_path = File.expand_path(@options[:derived_data_path] || Scan.config[:derived_data_path])
           xcresults = Dir.glob("#{derived_data_path}/Logs/Test/*.xcresult")
+          if FastlaneCore::Helper.xcode_at_least?('11.0.0')
+            xcresults += Dir.glob("#{output_directory}/*.xcresult")
+          end
           FastlaneCore::UI.verbose("Deleting xcresults:")
           xcresults.each do |xcresult|
             FastlaneCore::UI.verbose("  #{xcresult}")


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

Updates how test_results are collated for Xcode 11. The Info.plist file no longer contains the tests in the Info.plist file.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md