### PR TITLE
Fixes issue 148 and issue 146

### DIFF
--- a/AtomicBoy/AtomicBoy.xcodeproj/project.pbxproj
+++ b/AtomicBoy/AtomicBoy.xcodeproj/project.pbxproj
@@ -195,7 +195,6 @@
 				1FAF0F58EBBEC00467643CF0 /* Pods-KiwiTests.release.xcconfig */,
 				4C050727974CFB3DA6DD48AD /* Pods-KiwiTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -728,7 +727,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AtomicBoyUITests/AtomicBoyUITests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = AtomicBoy;
 			};
@@ -745,7 +744,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.appian.AtomicBoyUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "AtomicBoyUITests/AtomicBoyUITests-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = AtomicBoy;
 			};

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -15,6 +15,7 @@ module Fastlane
 
         prepare_for_testing(params.values)
         
+        coerce_destination_to_array(params)
         platform = :mac
         platform = :ios_simulator if Scan.config[:destination].any? { |d| d.include?('platform=iOS Simulator') }
 
@@ -29,6 +30,13 @@ module Fastlane
           raise UI.test_failure!('Tests have failed')
         end
         summary
+      end
+
+      def self.coerce_destination_to_array(params)
+        destination = params[:destination] || Scan.config[:destination] || []
+        unless destination.kind_of?(Array)
+          params[:destination] = Scan.config[:destination] = [destination] 
+        end
       end
 
       def self.print_multi_scan_parameters(params)

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -308,6 +308,13 @@ module Fastlane
             end
           ),
           FastlaneCore::ConfigItem.new(
+            key: :pre_delete_cloned_simulators,
+            description: 'Delete left over cloned simulators before running a parallel testrun',
+            optional: true,
+            is_string: false,
+            default_value: true
+          ),
+          FastlaneCore::ConfigItem.new(
             key: :testrun_completed_block,
             description: 'A block invoked each time a test run completes. When combined with :parallel_testrun_count, will be called separately in each child process',
             optional: true,

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/simulator_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/simulator_helper.rb
@@ -7,7 +7,7 @@ module TestCenter
         end
 
         def setup
-          if @options[:parallel_testrun_count] > 1
+          if @options[:parallel_testrun_count] > 1 && @options.fetch(:pre_delete_cloned_simulators, true)
             delete_multi_scan_cloned_simulators
           end
         end

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker_pool.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker_pool.rb
@@ -22,7 +22,8 @@ module TestCenter
           return [] unless @options[:platform] == :ios_simulator
 
           @simhelper = SimulatorHelper.new(
-            parallel_testrun_count: @options[:parallel_testrun_count]
+            parallel_testrun_count: @options[:parallel_testrun_count],
+            pre_delete_cloned_simulators: @options.fetch(:pre_delete_cloned_simulators, true)
           )
           @simhelper.setup
           @clones = @simhelper.clone_destination_simulators

--- a/spec/multi_scan_manager/simulator_helper_spec.rb
+++ b/spec/multi_scan_manager/simulator_helper_spec.rb
@@ -39,7 +39,7 @@ module TestCenter::Helper::MultiScanManager
     end
 
     describe 'setup' do
-      it 'deletes pre-existing simulator clones' do          
+      it 'deletes pre-existing simulator clones when :pre_delete_cloned_simulators' do          
         helper = SimulatorHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           project: File.absolute_path('AtomicBoy/AtomicBoy.xcodeproj'),
@@ -47,6 +47,17 @@ module TestCenter::Helper::MultiScanManager
           parallel_testrun_count: 4
         )
         expect(helper).to receive(:delete_multi_scan_cloned_simulators)
+        helper.setup
+      end
+      it 'does not delete pre-existing simulator clones when :pre_delete_cloned_simulators is false' do          
+        helper = SimulatorHelper.new(
+          derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
+          project: File.absolute_path('AtomicBoy/AtomicBoy.xcodeproj'),
+          scheme: 'Atlas',
+          parallel_testrun_count: 4,
+          pre_delete_cloned_simulators: false
+        )
+        expect(helper).not_to receive(:delete_multi_scan_cloned_simulators)
         helper.setup
       end
     end

--- a/spec/multi_scan_spec.rb
+++ b/spec/multi_scan_spec.rb
@@ -257,6 +257,27 @@ module Fastlane::Actions
         )
       end
 
+      it 'returns the result when nothing catastrophic goes on and :destination is a string' do
+        allow(Scan).to receive(:config).and_return(
+          destination: 'platform=iOS Simulator'
+        )
+        
+        mocked_runner = OpenStruct.new
+        allow(mocked_runner).to receive(:run).and_return(false)
+        allow(::TestCenter::Helper::MultiScanManager::Runner).to receive(:new).and_return(mocked_runner)
+        run_summary_mock = { this_to_shall_pass: true }
+        expect(MultiScanAction).to receive(:run_summary).and_return(run_summary_mock)
+        expect(MultiScanAction).to receive(:prepare_for_testing)
+        
+        options_mock = {
+          try_count: 1
+        }
+        allow(options_mock).to receive(:values).and_return(options_mock)
+        allow(options_mock).to receive(:_values).and_return(options_mock)
+        summary = MultiScanAction.run(options_mock)
+        expect(summary).to eq(run_summary_mock)
+      end
+      
       it 'returns the result when nothing catastrophic goes on' do
         mocked_runner = OpenStruct.new
         allow(mocked_runner).to receive(:run).and_return(false)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes two issues: #148, a crash when the client passes in a string for the `:destination` which works fine on `scan`, and #146  with running parallel `multi_scans` in parallel: deletion of the cloned simulators.

### Description
<!-- Describe your changes in detail -->

1. For the first issue, I coerce the `:destination` parameter to an array.
2. For the second issue, I provide a new option to _not_ delete the cloned simulators before running `multi_scan` in parallel.


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md