### PR TITLE
Issue 150 crash with html collation ruby 2.6.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,16 @@ jobs:
         bundle install
     - name: test
       run: rake
+
+  test_on_latest_ruby:
+    name: Run Tests with the latest Ruby
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: setup
+      run: |
+        gem install bundler
+        bundle install
+    - name: test
+      run: rake
+        

--- a/spec/html_test_report_spec.rb
+++ b/spec/html_test_report_spec.rb
@@ -71,7 +71,9 @@ module TestCenter::Helper::HtmlTestReport
           html_report2 = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-2.html'))))
           html_report.collate_report(html_report2)
           expect(html_report.testsuites.map(&:passing?)).to eq([false, true])
-          failing_testcase_details = REXML::XPath.match(html_report.root, ".//*[contains(@class, 'tests')]//*[contains(@class, 'details') and contains(@class, 'failing')]")
+
+          xpath_class_attributes = [ "contains(concat(' ', @class, ' '), ' details ')", "contains(concat(' ', @class, ' '), ' failing ')" ].join(' and ')
+          failing_testcase_details = REXML::XPath.match(html_report.root, ".//*[#{xpath_class_attributes}]")
           expect(failing_testcase_details.size).to eq(2)
         end
 
@@ -359,9 +361,9 @@ module TestCenter::Helper::HtmlTestReport
           testsuites = html_report.testsuites
           atomic_boy_ui_testcase1 = testsuites[0].testcases[0]
           failure_details = atomic_boy_ui_testcase1.failure_details
-          failure_reason = REXML::XPath.first(failure_details, "//[contains(@class, 'reason')]/text()").to_s
+          failure_reason = REXML::XPath.first(failure_details, "//*[contains(@class, 'reason')]/text()").to_s
           expect(failure_reason).to eq('((false) is true) failed')
-          failure_location = REXML::XPath.first(failure_details, "//[@class = 'test-detail']/text()").to_s
+          failure_location = REXML::XPath.first(failure_details, "//*[@class = 'test-detail']/text()").to_s
           expect(failure_location).to eq('AtomicBoyUITests.m:40')
         end
       end
@@ -401,9 +403,9 @@ module TestCenter::Helper::HtmlTestReport
 
           atomic_boy_ui_swift_passing_testcase.update_testcase(atomic_boy_ui_failing_testcase)
           failure_details = atomic_boy_ui_swift_passing_testcase.failure_details
-          failure_reason = REXML::XPath.first(failure_details, "//[contains(@class, 'reason')]/text()").to_s
+          failure_reason = REXML::XPath.first(failure_details, "//*[contains(@class, 'reason')]/text()").to_s
           expect(failure_reason).to eq('XCTAssertTrue failed - ')
-          failure_location = REXML::XPath.first(failure_details, "//[@class = 'test-detail']/text()").to_s
+          failure_location = REXML::XPath.first(failure_details, "//*[@class = 'test-detail']/text()").to_s
           expect(failure_location).to eq('SwiftAtomicBoyUITests.swift:14')
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes a crashing Issue #150 that occurs on Ruby 2.6.x when collating HTML files.

### Description
<!-- Describe your changes in detail -->

1. Remove some complexity from how individual test cases are found by name to avoid some issues in REXML for Ruby 2.6.x.
2. Loosen up the coupling for what nodes are searched for.
3. Add a Ruby 2.6.x matrix for testing that version.


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md