### PR TITLE
issue-145 fix broken collate_test_result_bundles refactor

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
@@ -37,12 +37,14 @@ module Fastlane
               Please install and select Xcode 11, and then run the command again.""")
           end
           xcresulttool_merge(params)
+          return true
         end
         FastlaneCore::UI.verbose("result bundles are NOT of format version 3")
         return false
       end
 
       def self.xcresulttool_merge(params)
+        test_result_bundlepaths = params[:bundles]
         collated_bundlepath = File.expand_path(params[:collated_bundle])
         Dir.mktmpdir do |dir|
           tmp_xcresult_bundlepaths = []
@@ -64,7 +66,6 @@ module Fastlane
           FileUtils.rm_rf(collated_bundlepath)
           FileUtils.cp_r(tmp_collated_bundlepath, collated_bundlepath)
           UI.message("Finished collating test_result bundle to '#{collated_bundlepath}'")
-          return true
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

`collate_test_result_bundles` was broken before releasing `3.8.7` due to insufficient testing after refactoring. This fixes that issue #145.

### Description
<!-- Describe your changes in detail -->

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md