### PR TITLE
Added shellscape for result bundle files

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
@@ -59,8 +59,10 @@ module Fastlane
           tmp_collated_bundlepath = File.join(dir, File.basename(collated_bundlepath))
           xcresulttool_cmd = 'xcrun xcresulttool merge '
           xcresulttool_cmd += tmp_xcresult_bundlepaths.map(&:shellescape).join(' ')
-          xcresulttool_cmd += " --output-path #{tmp_collated_bundlepath}"
+          xcresulttool_cmd += " --output-path #{tmp_collated_bundlepath.shellescape}"
+          UI.message("%%%%%%%%%%%%%%%%%%%%%%%%%%%")
           UI.message(xcresulttool_cmd)
+          UI.message("%%%%%%%%%%%%%%%%%%%%%%%%%%%")
           sh(xcresulttool_cmd)
           FileUtils.safe_unlink(tmp_xcresult_bundlepaths)
           FileUtils.rm_rf(collated_bundlepath)

--- a/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb
@@ -60,9 +60,7 @@ module Fastlane
           xcresulttool_cmd = 'xcrun xcresulttool merge '
           xcresulttool_cmd += tmp_xcresult_bundlepaths.map(&:shellescape).join(' ')
           xcresulttool_cmd += " --output-path #{tmp_collated_bundlepath.shellescape}"
-          UI.message("%%%%%%%%%%%%%%%%%%%%%%%%%%%")
           UI.message(xcresulttool_cmd)
-          UI.message("%%%%%%%%%%%%%%%%%%%%%%%%%%%")
           sh(xcresulttool_cmd)
           FileUtils.safe_unlink(tmp_xcresult_bundlepaths)
           FileUtils.rm_rf(collated_bundlepath)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [X] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [X] I've read the [Contribution Guidelines][contributing doc]
- [X] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Many times scheme names could have space. This results in failure, this PR will resolve that
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/issues/159
<!-- Please describe in detail how you tested your changes. -->
Ran all the tests suggested by repo

### Description
Just added shellescape to https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/blob/16599a56dad0f3e5f7b490c5123be20e9a27889e/lib/fastlane/plugin/test_center/actions/collate_test_result_bundles.rb#L62

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md