### PR TITLE
issue-165 fix test_without_building build conflict

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -170,9 +170,10 @@ module Fastlane
       end
 
       def self.prepare_scan_options_for_build_for_testing(scan_options)
+        build_options = scan_options.merge(build_for_testing: true).reject { |k| k == :test_without_building }
         Scan.config = FastlaneCore::Configuration.create(
           Fastlane::Actions::ScanAction.available_options,
-          ScanHelper.scan_options_from_multi_scan_options(scan_options.merge(build_for_testing: true))
+          ScanHelper.scan_options_from_multi_scan_options(build_options)
         )
         values = Scan.config.values(ask: false)
         values[:xcode_path] = File.expand_path("../..", FastlaneCore::Helper.xcode_path)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes Issue #165. When calling `multi_scan` with the `:test_without_building` option, it will conflict with the request to `:build_without_testing` option.

### Description
<!-- Describe your changes in detail -->

Remove the `:test_without_building` option when requesting `scan` to build.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md