### PR TITLE
fix issue-169 multi_scan crash when collating test_results

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
@@ -115,8 +115,7 @@ module TestCenter
 
           test_result_bundlepaths = sort_globbed_files("#{@source_reports_directory_glob}/#{@scheme}*.test_result")
           result_bundlename_suffix = ''
-          result_bundlename_suffix = "-#{@reportnamer.report_count + 1}" if @reportnamer.report_count > 0
-
+          result_bundlename_suffix = "-#{@reportnamer.report_count}" if @reportnamer.report_count > 0
           collated_test_result_bundlepath = File.absolute_path("#{File.join(@output_directory, @scheme)}#{result_bundlename_suffix}.test_result")
           if test_result_bundlepaths.size > 1
             FastlaneCore::UI.verbose("Collating test_result bundles #{test_result_bundlepaths}")
@@ -130,7 +129,7 @@ module TestCenter
             CollateTestResultBundlesAction.run(config)
             FileUtils.rm_rf(test_result_bundlepaths - [collated_test_result_bundlepath])
           elsif test_result_bundlepaths.size == 1 && File.realdirpath(test_result_bundlepaths.first) != File.realdirpath(collated_test_result_bundlepath)
-            FastlaneCore::UI.verbose("Copying test_result bundle #{test_result_bundlepaths.first}")
+            FastlaneCore::UI.verbose("Copying test_result bundle from #{test_result_bundlepaths.first} to #{collated_test_result_bundlepath}")
             FileUtils.mkdir_p(File.dirname(collated_test_result_bundlepath))
             FileUtils.mv(test_result_bundlepaths.first, collated_test_result_bundlepath)
           end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes issue #169 where the test_result bundles were renamed inappropriately and caused subsequent retries to fail when the unexpected test_result bundle already existed.

### Description
<!-- Describe your changes in detail -->

Fix the suffix for the collated test_result bundle file.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md