### PR TITLE
issue-182 remove spaces between report types

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,11 +38,6 @@ Style/MethodMissingSuper:
 Style/MissingRespondToMissing:
   Enabled: false
 
-# This rule isn't useful, lots of discussion happening around it also
-# e.g. https://github.com/bbatsov/rubocop/issues/2338
-MultilineBlockChain:
-  Enabled: false
-
 #
 #   File.chmod(0777, f)
 #
@@ -77,10 +72,10 @@ Lint/UselessAssignment:
     - '**/spec/**/*'
 
 # We could potentially enable the 2 below:
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: false
 
-Layout/AlignHash:
+Layout/HashAlignment:
   Enabled: false
 
 # HoundCI doesn't like this rule
@@ -99,7 +94,7 @@ Layout/TrailingWhitespace:
   Enabled: true
 
 # We still support Ruby 2.0.0
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 # This cop would not work fine with rspec
@@ -108,7 +103,7 @@ Style/MixinGrouping:
     - '**/spec/**/*'
 
 # Sometimes we allow a rescue block that doesn't contain code
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 # Cop supports --auto-correct.
@@ -165,7 +160,7 @@ Metrics/ClassLength:
 
 
 # Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 370
 
 # Configuration parameters: CountKeywordArgs.

--- a/fastlane-plugin-test_center.gemspec
+++ b/fastlane-plugin-test_center.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'colorize'
 
   spec.add_development_dependency 'cocoapods'
-  spec.add_development_dependency 'bundler', '2.0.2'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'fastlane', '>= 2.108.0'
   spec.add_development_dependency 'markdown-tables'
   spec.add_development_dependency 'pry'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,3 +9,13 @@ lane :run_examples do
     # rubocop:enable Security/Eval
   end
 end
+
+lane :testing do
+  multi_scan(
+    project: File.absolute_path('../AtomicBoy/AtomicBoy.xcodeproj'),
+    scheme: 'AtomicBoy',
+    try_count: 3,
+    batch_count: 4,
+    fail_build: false
+  )
+end

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -14,6 +14,12 @@ module Fastlane
     class MultiScanAction < Action
       def self.run(params)
         params[:quit_simulators] = params._values[:force_quit_simulator] if params._values[:force_quit_simulator]
+        if params[:output_types]
+          params[:output_types] = params[:output_types].split(',').map(&:strip).join(',')
+        end
+        if params[:output_files]
+          params[:output_files] = params[:output_files].split(',').map(&:strip).join(',')
+        end
 
         print_multi_scan_parameters(params)
         force_quit_simulator_processes if params[:quit_simulators]


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

As per #182, `multi_scan` will crash if it is given a comma separated list of `:output_types` with spaces after the commas.

### Description
<!-- Describe your changes in detail -->

Remove the spaces as soon as `multi_scan` starts.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md