### PR TITLE
issue-180 better handle crashing tests for retry

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -240,7 +240,7 @@ module TestCenter
               junit: File.absolute_path(report_filepath)
             }
           )
-          @options[:only_testing] = Fastlane::Actions::TestsFromJunitAction.run(config)[:failed].map(&:shellsafe_testidentifier)
+          @options[:only_testing] = @options[:only_testing] - Fastlane::Actions::TestsFromJunitAction.run(config).fetch(:passing, Hash.new).map(&:shellsafe_testidentifier)
           if @options[:invocation_based_tests]
             @options[:only_testing] = @options[:only_testing].map(&:strip_testcase).uniq
           end

--- a/spec/multi_scan_manager/retrying_scan_helper_spec.rb
+++ b/spec/multi_scan_manager/retrying_scan_helper_spec.rb
@@ -138,13 +138,14 @@ module TestCenter::Helper::MultiScanManager
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
           failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
         )
-        
+
         allow(Dir).to receive(:glob).with(%r{/.*/path/to/output/directory/.*\.test_result}).and_return(['./AtomicDragon.test_result', './AtomicDragon-99.test_result'])
         allow(FileUtils).to receive(:mkdir_p)
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           output_directory: File.absolute_path('./path/to/output/directory'),
-          result_bundle: true
+          result_bundle: true,
+          only_testing: []
         )
         expect(File).to receive(:rename).with('./AtomicDragon.test_result', './AtomicDragon-1.test_result')
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
@@ -171,7 +172,7 @@ module TestCenter::Helper::MultiScanManager
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{.*/path/to/output/directory/report(-\d)?\.junit}).and_return(true)
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
-          failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
+          passing: []
         )
         mocked_report_collator = OpenStruct.new
         expect(TestCenter::Helper::MultiScanManager::ReportCollator).to receive(:new)
@@ -189,7 +190,8 @@ module TestCenter::Helper::MultiScanManager
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           scheme: 'AtomicUITests',
           output_directory: File.absolute_path('./path/to/output/directory'),
-          collate_reports: true
+          collate_reports: true,
+          only_testing: ['BagOfTests/CoinTossingUITests/testResultIsTails']
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
@@ -200,7 +202,7 @@ module TestCenter::Helper::MultiScanManager
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{.*/path/to/output/directory/report(-\d)?\.junit}).and_return(true)
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
-          failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
+          passing: []
         )
         mocked_report_collator = OpenStruct.new
         expect(TestCenter::Helper::MultiScanManager::ReportCollator).to receive(:new)
@@ -218,7 +220,8 @@ module TestCenter::Helper::MultiScanManager
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           scheme: 'AtomicUITests',
           output_directory: File.absolute_path('./path/to/output/directory'),
-          collate_reports: true
+          collate_reports: true,
+          only_testing: ['BagOfTests/CoinTossingUITests/testResultIsTails']
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
       end
@@ -277,7 +280,7 @@ module TestCenter::Helper::MultiScanManager
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           only_testing: ['BagOfTests/CoinTossingUITests/testResultIsTails'],
-          output_directory: File.absolute_path('./path/to/output/directory')
+          output_directory: File.absolute_path('./path/to/output/directory'),
         )
 
         expect(helper.scan_options).to include(
@@ -309,7 +312,7 @@ module TestCenter::Helper::MultiScanManager
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{path/to/output/directory/report.junit}).and_return(true)
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
-          failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
+          passing: ['BagOfTests/CoinTossingUITests/testResultIsHeads']
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
         expect(helper.scan_options).to include(
@@ -321,7 +324,7 @@ module TestCenter::Helper::MultiScanManager
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{path/to/output/directory/coinTossResult(-\d)?.junit}).and_return(true)
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
-          failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
+          passing: ['BagOfTests/CoinTossingUITests/testResultIsHeads']
         )
 
         helper = RetryingScanHelper.new(
@@ -361,7 +364,7 @@ module TestCenter::Helper::MultiScanManager
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{.*/path/to/output/directory/BagOfTests-batch-3/coinTossResult(-\d)?.junit}).and_return(true)
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
-          failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
+          passing: ['BagOfTests/CoinTossingUITests/testResultIsHeads']
         )
 
         helper = RetryingScanHelper.new(
@@ -381,7 +384,7 @@ module TestCenter::Helper::MultiScanManager
         expect(scan_options[:output_files].split(',')).to include(
           'coinTossResult.html', 'coinTossResult.junit'
         )
-        
+
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
 
         scan_options = helper.scan_options
@@ -398,12 +401,12 @@ module TestCenter::Helper::MultiScanManager
           'coinTossResult-3.html', 'coinTossResult-3.junit'
         )
       end
- 
+
       it 'continually increments the report suffix for json' do
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{path/to/output/directory/report(-\d)?.xml}).and_return(true)
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
-          failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
+          passing: ['BagOfTests/CoinTossingUITests/testResultIsHeads']
         )
 
         helper = RetryingScanHelper.new(
@@ -513,13 +516,14 @@ module TestCenter::Helper::MultiScanManager
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{.*/path/to/output/directory/report\.junit}).and_return(true)
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
-          failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
+          passing: []
         )
-        
+
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           output_directory: File.absolute_path('./path/to/output/directory'),
-          code_coverage: true
+          code_coverage: true,
+          only_testing: ['BagOfTests/CoinTossingUITests/testResultIsTails']
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
         expect(helper.scan_options).not_to have_key(:code_coverage)
@@ -575,11 +579,12 @@ module TestCenter::Helper::MultiScanManager
         test_run_block = lambda do |testrun_info|
           actual_testrun_info = testrun_info
         end
-        
+
         helper = RetryingScanHelper.new(
           derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
           output_directory: File.absolute_path('./path/to/output/directory'),
-          testrun_completed_block: test_run_block
+          testrun_completed_block: test_run_block,
+          only_testing: []
         )
         allow(helper).to receive(:failure_details).and_return(
           [


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

Fix issue #180 where tests that crash are not retried.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

When a test fails, it is reported and is retried. If a test crashes, it is not recorded as failing and thus is not retried.

### Description
<!-- Describe your changes in detail -->

Instead of retrying failing tests, retry the tests that are left over from the original list of tests.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
