### PR TITLE
issue-178 clone sims by name, not id

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,9 +14,11 @@ lane :testing do
   multi_scan(
     workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
     scheme: 'AtomicBoy',
+    parallel_testrun_count: 2,
     try_count: 3,
     output_types: 'xcresult',
     output_files: 'result.xcresult',
-    fail_build: false
+    fail_build: false,
+    destination: 'platform=iOS Simulator,name=iPhone 8,OS=13.3'
   )
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Issue #178, `multi_scan` will fail when parallelizing tests because it cannot duplicate the found simulator if it is specified via the `destination` field.

### Description
<!-- Describe your changes in detail -->

Updated the code that clones the chosen simulators by using the id OR the details of the name and the OS version.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
