### PR TITLE
issue-183 warn when parallelizing on Circle CI

### DIFF
--- a/spec/multi_scan_spec.rb
+++ b/spec/multi_scan_spec.rb
@@ -278,7 +278,8 @@ module Fastlane::Actions
         expect(MultiScanAction).to receive(:prepare_for_testing)
 
         options_mock = {
-          try_count: 1
+          try_count: 1,
+          parallel_testrun_count: 1
         }
         allow(options_mock).to receive(:values).and_return(options_mock)
         allow(options_mock).to receive(:_values).and_return(options_mock)
@@ -295,7 +296,8 @@ module Fastlane::Actions
         expect(MultiScanAction).to receive(:prepare_for_testing)
 
         options_mock = {
-          try_count: 1
+          try_count: 1,
+          parallel_testrun_count: 1
         }
         allow(options_mock).to receive(:values).and_return(options_mock)
         allow(options_mock).to receive(:_values).and_return(options_mock)
@@ -312,7 +314,8 @@ module Fastlane::Actions
 
         options_mock = {
           try_count: 1,
-          fail_build: true
+          fail_build: true,
+          parallel_testrun_count: 1
         }
         allow(options_mock).to receive(:values).and_return(options_mock)
         allow(options_mock).to receive(:_values).and_return(options_mock)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Address issue #183 by warning of potential problems when parallelizing with `multi_scan` on Circle CI issues.

### Description
<!-- Describe your changes in detail -->

1. Check for parallelism and Circle CI.
1. Refactored `run` method for `multi_scan` to be a little cleaner and easy to read.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
