### PR TITLE
issue-207 clear out result bundle env var

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,7 +14,6 @@ lane :testing do
   multi_scan(
     workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
     scheme: 'AtomicBoy',
-    parallel_testrun_count: 2,
     try_count: 3,
     output_types: 'xcresult',
     output_files: 'result.xcresult',

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
@@ -20,8 +20,13 @@ module TestCenter
         def prepare_scan_config_for_destination
           # this allows multi_scan's `destination` option to be picked up by `scan`
           scan_config._values.delete(:device)
+          ENV.delete('SCAN_DEVICE')
           scan_config._values.delete(:devices)
-          scan_config._values.delete(:result_bundle) if ReportNameHelper.includes_xcresult?(@options[:output_types])
+          ENV.delete('SCAN_DEVICES')
+          if ReportNameHelper.includes_xcresult?(@options[:output_types])
+            scan_config._values.delete(:result_bundle)
+            ENV.delete('SCAN_RESULT_BUNDLE')
+          end
           scan_cache.clear
         end
 
@@ -35,7 +40,7 @@ module TestCenter
           FastlaneCore::UI.verbose("retrying_scan #update_scan_options")
           scan_options.each do |k,v|
             next if v.nil?
- 
+
             scan_config.set(k,v) unless v.nil?
             FastlaneCore::UI.verbose("\tSetting #{k.to_s} to #{v}")
           end
@@ -52,7 +57,7 @@ module TestCenter
           begin
             @retrying_scan_helper.before_testrun
             update_scan_options
-            
+
             values = scan_config.values(ask: false)
             values[:xcode_path] = File.expand_path("../..", FastlaneCore::Helper.xcode_path)
             ScanHelper.print_scan_parameters(values)

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -88,7 +88,7 @@ module TestCenter
 
         def scan_options
           valid_scan_keys = Fastlane::Actions::ScanAction.available_options.map(&:key)
-          xcargs = @options.fetch(:xcargs, '')
+          xcargs = @options[:xcargs] || ''
           if xcargs&.include?('build-for-testing')
             FastlaneCore::UI.important(":xcargs, #{xcargs}, contained 'build-for-testing', removing it")
             xcargs.slice!('build-for-testing')


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes #207 which occurs when the `:result_bundle` environment variable is set and a double `resultBundlePath` is sent to `xcodebuild` (which crashes it).

### Description
<!-- Describe your changes in detail -->

Clear out the following environment variables as well as the other `scan_options`:
- `SCAN_DEVICE`
- `SCAN_DEVICES`
- `SCAN_RESULT_BUNDLE`

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
