### PR TITLE
issue-119 clean up skip_testing option

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,7 @@ lane :testing do
   multi_scan(
     workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
     scheme: 'AtomicBoy',
+    skip_testing: ["AtomicBoyUITests/AtomicBoyUITests/testExample11"],
     try_count: 3,
     output_types: 'xcresult',
     output_files: 'result.xcresult',

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
@@ -17,16 +17,18 @@ module TestCenter
         end
         # :nocov:
 
-        def prepare_scan_config_for_destination
+        def prepare_scan_config
           # this allows multi_scan's `destination` option to be picked up by `scan`
           scan_config._values.delete(:device)
           ENV.delete('SCAN_DEVICE')
           scan_config._values.delete(:devices)
           ENV.delete('SCAN_DEVICES')
+          # this prevents double -resultBundlePath args to xcodebuild
           if ReportNameHelper.includes_xcresult?(@options[:output_types])
             scan_config._values.delete(:result_bundle)
             ENV.delete('SCAN_RESULT_BUNDLE')
           end
+          scan_config._values.delete(:skip_testing)
           scan_cache.clear
         end
 
@@ -35,8 +37,9 @@ module TestCenter
           scan_options = @options.select { |k,v| valid_scan_keys.include?(k) }
                                   .merge(@retrying_scan_helper.scan_options)
 
-          prepare_scan_config_for_destination
+          prepare_scan_config
           scan_options[:build_for_testing] = false
+          scan_options.delete(:skip_testing)
           FastlaneCore::UI.verbose("retrying_scan #update_scan_options")
           scan_options.each do |k,v|
             next if v.nil?

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -7,7 +7,7 @@ module TestCenter
       require 'json'
       require 'shellwords'
       require 'snapshot/reset_simulators'
-      
+
       class Runner
         attr_reader :retry_total_count
 
@@ -66,12 +66,12 @@ module TestCenter
           end
 
           unless tests_passed || @options[:try_count] < 1
-            setup_testcollector  
+            setup_testcollector
             tests_passed = run_test_batches
           end
           tests_passed
         end
-        
+
         def should_run_tests_through_single_try?
           should_run_for_invocation_tests = @options[:invocation_based_tests] && @options[:only_testing].nil?
           should_run_for_skip_build = @options[:skip_build]
@@ -114,16 +114,16 @@ module TestCenter
           end
           @options[:output_directory] = output_directory
           @options[:destination] = Scan.config[:destination]
-          
+
           # We do not want Scan.config to _not_ have :device :devices, we want to
           # use :destination. We remove :force_quit_simulator as we do not want
           # Scan to handle it as multi_scan takes care of it in its own way
           options = @options.reject { |key| %i[device devices force_quit_simulator].include?(key) }
           options[:try_count] = 1
-  
+
           tests_passed = RetryingScan.run(options)
           @options[:try_count] -= 1
-          
+
           reportnamer = ReportNameHelper.new(
             @options[:output_types],
             @options[:output_files],
@@ -138,12 +138,12 @@ module TestCenter
           )
           @options[:only_testing] = retrieve_failed_single_try_tests
           @options[:only_testing] = @options[:only_testing].map(&:strip_testcase).uniq
-          
+
           symlink_result_bundle_to_xcresult(output_directory, reportnamer)
 
           tests_passed
         end
-        
+
         def retrieve_failed_single_try_tests
           reportnamer = ReportNameHelper.new(
             @options[:output_types],
@@ -168,10 +168,10 @@ module TestCenter
 
           pool = TestBatchWorkerPool.new(pool_options)
           pool.setup_workers
-          
+
           remaining_test_batches = @test_collector.test_batches.clone
           remaining_test_batches.each_with_index do |test_batch, current_batch_index|
-            worker = pool.wait_for_worker              
+            worker = pool.wait_for_worker
             FastlaneCore::UI.message("Starting test run #{current_batch_index + 1}")
             worker.run(scan_options_for_worker(test_batch, current_batch_index))
           end
@@ -189,7 +189,7 @@ module TestCenter
             batch: batch_index + 1
           }
         end
-  
+
         def collate_batched_reports
           return unless @batch_count > 1
           return unless @options[:collate_reports]

--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -80,7 +80,7 @@ module TestCenter
               known_tests += xctestrun_known_tests[testable]
               test_components = test.split('/')
               testsuite = test_components.size == 1 ? test_components[0] : test_components[1]
-              @testables_tests[testable][index] = known_tests.select { |known_test| known_test.include?(testsuite) } 
+              @testables_tests[testable][index] = known_tests.select { |known_test| known_test.include?(testsuite) }
             end
           end
           @testables_tests[testable].flatten!
@@ -106,7 +106,7 @@ module TestCenter
             end
           end
         end
-        
+
         @testables_tests
       end
 

--- a/spec/multi_scan_manager/retrying_scan_spec.rb
+++ b/spec/multi_scan_manager/retrying_scan_spec.rb
@@ -18,22 +18,22 @@ module TestCenter::Helper::MultiScanManager
       @mock_scan_cache = { destination: ["platform=iOS Simulator,id=HungryHippo"] }
       allow_any_instance_of(RetryingScan).to receive(:scan_cache).and_return(@mock_scan_cache)
     end
-    
-    describe '#prepare_scan_config_for_destination' do
+
+    describe '#prepare_scan_config' do
       it 'removes :device and :devices' do
         retrying_scan = RetryingScan.new
 
         @mock_scan_config[:device] = 'iPhone 91v'
         @mock_scan_config[:devices] = ['iPhone 92w', 'iPhone 92x']
 
-        retrying_scan.prepare_scan_config_for_destination
+        retrying_scan.prepare_scan_config
         expect(@mock_scan_config[:device]).to be_nil
         expect(@mock_scan_config[:devices]).to be_nil
       end
 
       it 'clears out the Scan cache' do
         retrying_scan = RetryingScan.new
-        retrying_scan.prepare_scan_config_for_destination
+        retrying_scan.prepare_scan_config
         expect(@mock_scan_cache).to be_empty
       end
 
@@ -41,8 +41,8 @@ module TestCenter::Helper::MultiScanManager
         allow(ReportNameHelper).to receive(:includes_xcresult?).and_return(true)
         retrying_scan = RetryingScan.new
         @mock_scan_config[:result_bundle] = true
-        retrying_scan.prepare_scan_config_for_destination
-        expect(@mock_scan_config[:result_bundle]).to be_falsey 
+        retrying_scan.prepare_scan_config
+        expect(@mock_scan_config[:result_bundle]).to be_falsey
       end
     end
 
@@ -53,7 +53,7 @@ module TestCenter::Helper::MultiScanManager
             derived_data_path: './path/to/derived_data_path'
           }
         )
-        expect(retrying_scan).to receive(:prepare_scan_config_for_destination)
+        expect(retrying_scan).to receive(:prepare_scan_config)
         retrying_scan.update_scan_options
       end
     end
@@ -103,7 +103,7 @@ module TestCenter::Helper::MultiScanManager
         expect(@mock_scan_runner).to receive(:run).ordered.once
 
         retrying_scan = RetryingScan.new(try_count: 3)
-        
+
         test_result = retrying_scan.run
         expect(test_result).to be(true)
       end
@@ -147,7 +147,7 @@ module TestCenter::Helper::MultiScanManager
         end
         expect(@mock_scan_runner).to receive(:run).ordered.once
         expect(@mock_retrying_scan_helper).to receive(:before_testrun).exactly(3).times
-        
+
         retrying_scan = RetryingScan.new(try_count: 3)
         retrying_scan.run
       end
@@ -161,7 +161,7 @@ module TestCenter::Helper::MultiScanManager
         end
         expect(@mock_scan_runner).to receive(:run).ordered.once
         expect(@mock_retrying_scan_helper).to receive(:after_testrun).exactly(3).times
-        
+
         retrying_scan = RetryingScan.new(try_count: 3)
         retrying_scan.run
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Investigate #119 and found out that it now works. I probably fixed it in an earlier change. I cleaned this code up to no longer print it out as one of the tests that are skipped as that _could_ conflict with the only testing parameter sent to `scan`.


### Description
<!-- Describe your changes in detail -->

Remove `:skip_testing` from the options sent to `scan` for each test run.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
