### PR TITLE
issue-212 fix v2 xctestrun files test collection

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -42,9 +42,7 @@ module TestCenter
           if @only_testing
             @testables ||= only_testing_to_testables_tests.keys
           else
-            @testables ||= Plist.parse_xml(@xctestrun_path).keys.reject do |key|
-              key == '__xctestrun_metadata__'
-            end
+            @testables = xctestrun_known_tests.keys
           end
         end
         @testables
@@ -80,7 +78,7 @@ module TestCenter
               known_tests += xctestrun_known_tests[testable]
               test_components = test.split('/')
               testsuite = test_components.size == 1 ? test_components[0] : test_components[1]
-              @testables_tests[testable][index] = known_tests.select { |known_test| known_test.include?(testsuite) } 
+              @testables_tests[testable][index] = known_tests.select { |known_test| known_test.include?(testsuite) }
             end
           end
           @testables_tests[testable].flatten!
@@ -106,7 +104,7 @@ module TestCenter
             end
           end
         end
-        
+
         @testables_tests
       end
 

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -16,21 +16,21 @@ module TestCenter::Helper
         end
 
         it 'finds testable from given xctestrun' do
-          allow(Plist).to receive(:parse_xml).with('path/to/fake.xctestrun').and_return({ 'AtomicBoyTests' => [] })
           test_collector = TestCollector.new(
             xctestrun: 'path/to/fake.xctestrun'
           )
+          allow(test_collector).to receive(:xctestrun_known_tests).and_return({ 'AtomicBoyTests' => [] })
           expect(test_collector.testables).to eq(['AtomicBoyTests'])
         end
 
         it 'finds testables from derived xctestrun' do
           allow(File).to receive(:exist?).with("path/to/fake/derived_data/Build/Products/Professor_Blahblah.xctestrun").and_return(true)
           allow(Dir).to receive(:glob).with("path/to/fake/derived_data/Build/Products/*.xctestrun").and_return(['path/to/fake/derived_data/Build/Products/Professor_Blahblah.xctestrun'])
-          allow(Plist).to receive(:parse_xml).with("path/to/fake/derived_data/Build/Products/Professor_Blahblah.xctestrun").and_return({ 'AtomicBoyTests' => [], 'AtomicBoyUITests' => [] })
           test_collector = TestCollector.new(
             derived_data_path: 'path/to/fake/derived_data',
             scheme: 'Professor'
           )
+          allow(test_collector).to receive(:xctestrun_known_tests).and_return({ 'AtomicBoyTests' => [], 'AtomicBoyUITests' => [] })
           expect(test_collector.testables).to eq(['AtomicBoyTests', 'AtomicBoyUITests'])
         end
 
@@ -39,8 +39,9 @@ module TestCenter::Helper
           XCTEST_RUN_FILENAME = 'Professor_Blahblah.xctestrun'
           allow(File).to receive(:exist?).with("#{FAKE_DEFAULT_DERIVED_DATA_PATH}/Build/Products/#{XCTEST_RUN_FILENAME}").and_return(true)
           allow(Dir).to receive(:glob).with("#{FAKE_DEFAULT_DERIVED_DATA_PATH}/Build/Products/*.xctestrun").and_return(["#{FAKE_DEFAULT_DERIVED_DATA_PATH}/Build/Products/#{XCTEST_RUN_FILENAME}"])
-          allow(Plist).to receive(:parse_xml).with("#{FAKE_DEFAULT_DERIVED_DATA_PATH}/Build/Products/#{XCTEST_RUN_FILENAME}").and_return({ 'AtomicBoyTests' => [], 'AtomicBoyUITests' => [] })
+
           mocked_project = OpenStruct.new
+
           allow(mocked_project).to receive(:build_settings).and_return("#{FAKE_DEFAULT_DERIVED_DATA_PATH}/blah1/blah2/blah3")
           allow(File).to receive(:expand_path).with('../../..', "#{FAKE_DEFAULT_DERIVED_DATA_PATH}/blah1/blah2/blah3").and_return(FAKE_DEFAULT_DERIVED_DATA_PATH)
           allow(Scan).to receive(:project).and_return(mocked_project)
@@ -48,6 +49,7 @@ module TestCenter::Helper
             skip_build: true,
             scheme: 'Professor'
           )
+          allow(test_collector).to receive(:xctestrun_known_tests).and_return({ 'AtomicBoyTests' => [], 'AtomicBoyUITests' => [] })
           expect(test_collector.testables).to eq(['AtomicBoyTests', 'AtomicBoyUITests'])
         end
 
@@ -266,7 +268,7 @@ module TestCenter::Helper
           }
           allow(Plist).to receive(:parse_xml).and_return(mock_xctestrun)
           allow(File).to receive(:exist?).with('path/to/fake.xctestrun').and_return(true)
-          expect(Fastlane::Actions::TestsFromXctestrunAction).to receive(:run)
+          allow(Fastlane::Actions::TestsFromXctestrunAction).to receive(:run)
             .and_return(mock_xctestrun)
 
           test_collector = TestCollector.new(


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

When [v3.10.0](https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/tree/v3.10.0) was released, it introduced #212 which broke testing.

### Description
<!-- Describe your changes in detail -->

Get the testables based on the test targets that the action `tests_from_xctestrun` action: it handles v1 and v2 of the `xctestrun` files.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
