### PR TITLE
issue-219 Handle invocation tests for first run properly

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -245,7 +245,7 @@ module TestCenter
               junit: File.absolute_path(report_filepath)
             }
           )
-          @options[:only_testing] = @options[:only_testing] - Fastlane::Actions::TestsFromJunitAction.run(config).fetch(:passing, Hash.new).map(&:shellsafe_testidentifier)
+          @options[:only_testing] = (@options[:only_testing] || []) - Fastlane::Actions::TestsFromJunitAction.run(config).fetch(:passing, Hash.new).map(&:shellsafe_testidentifier)
           if @options[:invocation_based_tests]
             @options[:only_testing] = @options[:only_testing].map(&:strip_testcase).uniq
           end

--- a/spec/multi_scan_manager/retrying_scan_helper_spec.rb
+++ b/spec/multi_scan_manager/retrying_scan_helper_spec.rb
@@ -745,5 +745,22 @@ module TestCenter::Helper::MultiScanManager
         expect(scan_options[:xcargs]).not_to include('-parallel-testing-enabled=YES')
       end
     end
+
+    describe '#update_only_testing' do
+      it 'does not crash with an empty :only_testing' do
+        allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
+          failed: ['BagOfTests/CoinTossingUITests/testResultIsTails']
+        )
+        helper = RetryingScanHelper.new(
+          derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
+          output_directory: File.absolute_path('./spec/fixtures'),
+          output_types: 'junit',
+          output_files: 'junit.xml',
+          only_testing: nil,
+          xcargs: "-parallel-testing-enabled=YES"
+        )
+        helper.update_only_testing
+      end
+    end
   end
 end


### PR DESCRIPTION
After changing multi_scan to handle re-running only "non-failed" tests,
a bug was introduced where the 'invocation' tests aspect of the plugin
would fail after a test run. This fixes that.

<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

Fixes issue #219 to prevent crashes after a test run with the invocation tests option is selected.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->

Get an empty array if `:only_testing` is empty or nil.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
