### PR TITLE
issue-221 prevent testplan crash when building

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -87,6 +87,10 @@ Layout/HashAlignment:
 Layout/DotPosition:
   Enabled: false
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+
 # We allow !! as it's an easy way to convert ot boolean
 Style/DoubleNegation:
   Enabled: false
@@ -118,6 +122,12 @@ Lint/UnusedBlockArgument:
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 
+Lint/RaiseException:
+  Enabled: false
+
+Lint/StructNewOverride:
+  Enabled: false
+
 # Needed for $verbose
 Style/GlobalVars:
   Enabled: false
@@ -128,6 +138,9 @@ Style/ClassAndModuleChildren:
 
 # $? Exit
 Style/SpecialGlobalVars:
+  Enabled: false
+
+Style/ExponentialNotation:
   Enabled: false
 
 Metrics/AbcSize:

--- a/docs/feature_details/test_options_from_testplan.md
+++ b/docs/feature_details/test_options_from_testplan.md
@@ -1,0 +1,31 @@
+
+
+# ☑️  test_options_from_testplan
+
+Get the tests and test coverage values from a given testplan.
+
+## Example
+
+<!-- test_options_from_testplan examples: begin -->
+
+```ruby
+
+UI.important(
+  'example: ' \
+  'get the tests and the test coverage configuration from a given testplan'
+)
+test_options = test_options_from_testplan(
+  testplan: 'AtomicBoy/AtomicBoy_2.xctestplan'
+)
+UI.message("The AtomicBoy_2 testplan has the following tests: #{test_options[:only_testing'}")
+
+```
+<!-- test_options_from_testplan examples: end -->
+
+## Parameters
+
+<!-- test_options_from_testplan parameters: begin -->
+|Parameter|Description|Default Value|
+|:-|:-|-:|
+|testplan|The Xcode testplan to read the test info from||
+<!-- test_options_from_testplan parameters: end -->

--- a/docs/feature_details/testplans_from_scheme.md
+++ b/docs/feature_details/testplans_from_scheme.md
@@ -1,0 +1,34 @@
+
+
+# ☑️  testplans_from_scheme
+
+Get the testplans that an Xcode Scheme references.
+
+## Example
+
+<!-- testplans_from_scheme examples: begin -->
+
+```ruby
+
+UI.important(
+  'example: ' \
+  'get all the testplans that an Xcode Scheme references'
+)
+testplans = testplans_from_scheme(
+  xcodeproj: 'AtomicBoy/AtomicBoy.xcodeproj',
+  scheme: 'AtomicBoy'
+)
+UI.message("The AtomicBoy uses the following testplans: #{testplans}")
+
+```
+<!-- testplans_from_scheme examples: end -->
+
+## Parameters
+
+<!-- testplans_from_scheme parameters: begin -->
+|Parameter|Description|Default Value|
+|:-|:-|-:|
+|xcodeproj|The file path to the Xcode project file that references the Scheme||
+|workspace|The file path to the Xcode workspace file that references the Scheme||
+|scheme|The Xcode scheme referencing the testplan||
+<!-- testplans_from_scheme parameters: end -->

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,12 +10,20 @@ lane :run_examples do
   end
 end
 
+lane :testplan do
+  puts test_options_from_testplan(
+    workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
+    scheme: 'AtomicBoy',
+    testplan: 'AtomicBoy_2'
+  )
+end
+
 lane :testing do
   multi_scan(
     workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
-    scheme: 'Professor',
-    try_count: 0,
-    fail_build: false,
-    xcargs: '-quiet'
+    scheme: 'AtomicBoy',
+    testplan: 'AtomicBoy_2',
+    try_count: 3,
+    fail_build: false
   )
 end

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -232,7 +232,7 @@ module Fastlane
       end
 
       def self.prepare_scan_options_for_build_for_testing(scan_options)
-        build_options = scan_options.merge(build_for_testing: true).reject { |k| k == :test_without_building }
+        build_options = scan_options.merge(build_for_testing: true).reject { |k| %i[test_without_building, testplan].include?(k) }
         Scan.config = FastlaneCore::Configuration.create(
           Fastlane::Actions::ScanAction.available_options,
           ScanHelper.scan_options_from_multi_scan_options(build_options)
@@ -244,7 +244,11 @@ module Fastlane
       end
 
       def self.update_xctestrun_after_build(scan_options)
-        xctestrun_files = Dir.glob("#{Scan.config[:derived_data_path]}/Build/Products/*.xctestrun")
+        glob_pattern = "#{Scan.config[:derived_data_path]}/Build/Products/*.xctestrun"
+        if scan_options[:testplan]
+          glob_pattern = "#{Scan.config[:derived_data_path]}/Build/Products/*#{scan_options[:testplan]}*.xctestrun"
+        end
+        xctestrun_files = Dir.glob(glob_pattern)
         UI.verbose("After building, found xctestrun files #{xctestrun_files} (choosing 1st)")
         scan_options[:xctestrun] = xctestrun_files.first
       end

--- a/lib/fastlane/plugin/test_center/actions/test_options_from_testplan.rb
+++ b/lib/fastlane/plugin/test_center/actions/test_options_from_testplan.rb
@@ -1,0 +1,90 @@
+require 'json'
+
+module Fastlane
+  module Actions
+    class TestOptionsFromTestplanAction < Action
+      def self.run(params)
+        testplan_path = params[:testplan]
+
+        testplan = JSON.load(File.open(testplan_path))
+        only_testing = []
+        UI.verbose("Examining testplan JSON: #{testplan}")
+        testplan['testTargets'].each do |test_target|
+          testable = test_target.dig('target', 'name')
+          if test_target.key?('selectedTests')
+            UI.verbose("  Found selectedTests")
+            test_identifiers = test_target['selectedTests'].each do |selected_test|
+              UI.verbose("    Found test: '#{selected_test}'")
+              only_testing << "#{testable}/#{selected_test.sub('\/', '/')}"
+            end
+          else
+            UI.verbose("  No selected tests, using testable '#{testable}'")
+            only_testing << testable
+          end
+        end
+        {
+          code_coverage: testplan.dig('defaultOptions', 'codeCoverage'),
+          only_testing: only_testing
+        }
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "☑️ Gets test info from a given test plan"
+      end
+
+      def self.details
+        "Gets tests info consisting of tests to run and whether or not code coverage is enabled"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :testplan,
+            optional: true,
+            env_name: "FL_TEST_OPTIONS_FROM_TESTPLAN_TESTPLAN",
+            description: "The Xcode testplan to read the test info from",
+            verify_block: proc do |test_plan|
+              UI.user_error!("Error: Xcode Test Plan '#{test_plan}' is not valid!") if test_plan and test_plan.empty?
+              UI.user_error!("Error: Test Plan does not exist at path '#{test_plan}'") unless File.exist?(test_plan)
+            end
+          )
+        ]
+      end
+
+      def self.return_value
+        "Returns a Hash with keys :code_coverage and :only_testing for the given testplan"
+      end
+
+      def self.example_code
+        [
+          "
+          UI.important(
+            'example: ' \\
+            'get the tests and the test coverage configuration from a given testplan'
+          )
+          test_options = test_options_from_testplan(
+            testplan: 'AtomicBoy/AtomicBoy_2.xctestplan'
+          )
+          UI.message(\"The AtomicBoy_2 testplan has the following tests: \#{test_options[:only_testing]}\")
+          "
+        ]
+      end
+
+      def self.authors
+        ["lyndsey-ferguson/lyndseydf"]
+      end
+
+      def self.category
+        :testing
+      end
+
+      def self.is_supported?(platform)
+        %i[ios mac].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/test_center/actions/testplans_from_scheme.rb
+++ b/lib/fastlane/plugin/test_center/actions/testplans_from_scheme.rb
@@ -1,0 +1,120 @@
+module Fastlane
+  module Actions
+    class TestplansFromSchemeAction < Action
+      def self.run(params)
+        scheme = params[:scheme]
+        scheme_filepaths = schemes_from_project(params[:xcodeproj], scheme) || schemes_from_workspace(params[:workspace], scheme)
+        if scheme_filepaths.length.zero?
+          UI.user_error!("Error: cannot find any schemes in the Xcode project") if params[:xcodeproj]
+          UI.user_error!("Error: cannot find any schemes in the Xcode workspace") if params[:workspace]
+        end
+        testplan_paths = []
+        scheme_filepaths.each do |scheme_filepath|
+          UI.verbose("Looking in Scheme '#{scheme_filepath}' for any testplans")
+          xcscheme = Xcodeproj::XCScheme.new(scheme_filepath)
+          next if xcscheme.test_action.nil?
+          next if xcscheme.test_action.testables.to_a.empty?
+          next if xcscheme.test_action.testables[0].buildable_references.to_a.empty?
+          next if xcscheme.test_action.test_plans.to_a.empty?
+
+          xcodeproj = xcscheme.test_action.testables[0].buildable_references[0].target_referenced_container.sub('container:', '')
+          container_dir = scheme_filepath.sub(/#{xcodeproj}.*/, '')
+          xcscheme.test_action.test_plans.each do |testplan|
+            testplan_path = File.absolute_path(File.join(container_dir, testplan.target_referenced_container.sub('container:', '')))
+            UI.verbose("  found testplan '#{testplan_path}'")
+            testplan_paths << testplan_path
+          end
+        end
+        testplan_paths
+      end
+
+      def self.schemes_from_project(project_path, scheme)
+        return nil unless project_path
+
+        Dir.glob("#{project_path}/{xcshareddata,xcuserdata}/**/xcschemes/#{scheme || '*'}.xcscheme")
+      end
+
+      def self.schemes_from_workspace(workspace_path, scheme)
+        return nil unless workspace_path
+
+        xcworkspace = Xcodeproj::Workspace.new_from_xcworkspace(workspace_path)
+        scheme_filepaths = []
+        xcworkspace.file_references.each do |file_reference|
+          next if file_reference.path.include?('Pods/Pods.xcodeproj')
+
+          project_path = file_reference.absolute_path(File.dirname(workspace_path))
+          scheme_filepaths.concat(schemes_from_project(project_path, scheme))
+        end
+        scheme_filepaths
+      end
+
+      def self.description
+        "☑️Gets all the testplans that a Scheme references"
+      end
+
+      def self.authors
+        ["lyndsey-ferguson/lyndseydf"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(
+            key: :xcodeproj,
+            env_name: "FL_TESTPLANS_FROM_SCHEME_XCODE_PROJECT",
+            optional: true,
+            description: "The file path to the Xcode project file that references the Scheme",
+            verify_block: proc do |path|
+              path = File.expand_path(path.to_s)
+              UI.user_error!("Error: Xcode project file path not given!") unless path and !path.empty?
+              UI.user_error!("Error: Xcode project '#{path}' not found!") unless Dir.exist?(path)
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :workspace,
+            env_name: "FL_TESTPLANS_FROM_SCHEME_XCODE_WORKSPACE",
+            optional: true,
+            description: "The file path to the Xcode workspace file that references the Scheme",
+            verify_block: proc do |value|
+              v = File.expand_path(value.to_s)
+              UI.user_error!("Error: Workspace file not found at path '#{v}'") unless Dir.exist?(v)
+              UI.user_error!("Error: Workspace file is not a workspace, must end with .xcworkspace") unless v.include?(".xcworkspace")
+            end
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :scheme,
+            optional: true,
+            env_name: "FL_TESTPLANS_FROM_SCHEME_XCODE_SCHEME",
+            description: "The Xcode scheme referencing the testplan",
+            verify_block: proc do |scheme_name|
+              UI.user_error!("Error: Xcode Scheme '#{scheme_name}' is not valid!") if scheme_name and scheme_name.empty?
+            end
+          )
+        ]
+      end
+
+      def self.example_code
+        [
+          "
+          UI.important(
+            'example: ' \\
+            'get all the testplans that an Xcode Scheme references'
+          )
+          testplans = testplans_from_scheme(
+            xcodeproj: 'AtomicBoy/AtomicBoy.xcodeproj',
+            scheme: 'AtomicBoy'
+          )
+          UI.message(\"The AtomicBoy uses the following testplans: \#{testplans}\")
+          "
+        ]
+      end
+
+      def self.category
+        :testing
+      end
+
+      def self.is_supported?(platform)
+        %i[ios mac].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager.rb
@@ -1,3 +1,5 @@
+require_relative 'reportname_helper'
+require_relative 'test_collector'
 require_relative 'multi_scan_manager/device_manager'
 require_relative 'multi_scan_manager/report_collator'
 require_relative 'multi_scan_manager/retrying_scan_helper'

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -1,4 +1,3 @@
-
 module TestCenter
   module Helper
     module MultiScanManager
@@ -40,7 +39,8 @@ module TestCenter
           return if @options[:invocation_based_tests] && @options[:only_testing].nil?
           return if @test_collector
 
-          @test_collector = TestCenter::Helper::TestCollector.new(@options)
+          @test_collector = TestCollector.new(@options)
+          @options.reject! { |key| %i[testplan].include?(key) }
           @batch_count = @test_collector.test_batches.size
         end
 

--- a/spec/fixtures/code-coverage-no.xctestplan
+++ b/spec/fixtures/code-coverage-no.xctestplan
@@ -1,0 +1,44 @@
+{
+  "configurations": [
+    {
+      "id": "1162AED2-E8D8-44D4-82D6-3290F84BA621",
+      "name": "Configuration 1",
+      "options": {
+      }
+    }
+  ],
+  "defaultOptions": {
+    "codeCoverage": false,
+    "targetForVariableExpansion": {
+      "containerPath": "container:AtomicBoy.xcodeproj",
+      "identifier": "26DB0F4E1FA12D4B0023C31D",
+      "name": "AtomicBoy"
+    }
+  },
+  "testTargets": [
+    {
+      "selectedTests": [
+        "AtomicBoyTests\/testExample",
+        "AtomicBoyTests\/testPerformanceExample"
+      ],
+      "target": {
+        "containerPath": "container:AtomicBoy.xcodeproj",
+        "identifier": "26DB0F6D1FA12D4B0023C31D",
+        "name": "AtomicBoyTests"
+      }
+    },
+    {
+      "selectedTests": [
+        "AtomicBoyUITests\/testExample",
+        "AtomicBoyUITests\/testExample2",
+        "AtomicBoyUITests\/testExample3"
+      ],
+      "target": {
+        "containerPath": "container:AtomicBoy.xcodeproj",
+        "identifier": "26DB0F781FA12D4B0023C31D",
+        "name": "AtomicBoyUITests"
+      }
+    }
+  ],
+  "version": 1
+}

--- a/spec/fixtures/code-coverage.xctestplan
+++ b/spec/fixtures/code-coverage.xctestplan
@@ -1,0 +1,44 @@
+{
+  "configurations": [
+    {
+      "id": "1162AED2-E8D8-44D4-82D6-3290F84BA621",
+      "name": "Configuration 1",
+      "options": {
+      }
+    }
+  ],
+  "defaultOptions": {
+    "codeCoverage": true,
+    "targetForVariableExpansion": {
+      "containerPath": "container:AtomicBoy.xcodeproj",
+      "identifier": "26DB0F4E1FA12D4B0023C31D",
+      "name": "AtomicBoy"
+    }
+  },
+  "testTargets": [
+    {
+      "selectedTests": [
+        "AtomicBoyTests\/testExample",
+        "AtomicBoyTests\/testPerformanceExample"
+      ],
+      "target": {
+        "containerPath": "container:AtomicBoy.xcodeproj",
+        "identifier": "26DB0F6D1FA12D4B0023C31D",
+        "name": "AtomicBoyTests"
+      }
+    },
+    {
+      "selectedTests": [
+        "AtomicBoyUITests\/testExample",
+        "AtomicBoyUITests\/testExample2",
+        "AtomicBoyUITests\/testExample3"
+      ],
+      "target": {
+        "containerPath": "container:AtomicBoy.xcodeproj",
+        "identifier": "26DB0F781FA12D4B0023C31D",
+        "name": "AtomicBoyUITests"
+      }
+    }
+  ],
+  "version": 1
+}

--- a/spec/test_options_from_testplan_spec.rb
+++ b/spec/test_options_from_testplan_spec.rb
@@ -1,0 +1,55 @@
+module Fastlane::Actions
+  describe 'TestOptionsFromTestplanAction' do
+    describe '.available_options' do
+      it 'raises an error if the testplan does not exist' do
+        fastfile = "lane :test do
+          test_options_from_testplan(
+            testplan: 'path/to/non-existent.xctestplan'
+          )
+        end"
+
+        expect { Fastlane::FastFile.new.parse(fastfile).runner.execute(:test) }.to(
+          raise_error(FastlaneCore::Interface::FastlaneError) do |error|
+            expect(error.message).to match(%r{Error: Test Plan does not exist at path 'path/to/non-existent.xctestplan'})
+          end
+        )
+      end
+    end
+
+    describe '#run' do
+      it 'returns the correct code_coverage values' do
+        fastfile = "lane :test do
+          test_options_from_testplan(
+            testplan: '../spec/fixtures/code-coverage.xctestplan'
+          )
+        end"
+        result = Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
+        expect(result[:code_coverage]).to eq(true)
+
+        fastfile = "lane :test do
+          test_options_from_testplan(
+            testplan: '../spec/fixtures/code-coverage-no.xctestplan'
+          )
+        end"
+        result = Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
+        expect(result[:code_coverage]).to eq(false)
+      end
+      it 'returns the correct only_testing values' do
+        fastfile = "lane :test do
+          test_options_from_testplan(
+            testplan: '../spec/fixtures/code-coverage-no.xctestplan'
+          )
+        end"
+        result = Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
+        expect(result[:only_testing]).to contain_exactly(
+          "AtomicBoyTests/AtomicBoyTests/testExample",
+          "AtomicBoyTests/AtomicBoyTests/testPerformanceExample",
+          "AtomicBoyUITests/AtomicBoyUITests/testExample",
+          "AtomicBoyUITests/AtomicBoyUITests/testExample2",
+          "AtomicBoyUITests/AtomicBoyUITests/testExample3"
+        )
+      end
+    end
+  end
+end
+

--- a/spec/testplans_from_scheme_spec.rb
+++ b/spec/testplans_from_scheme_spec.rb
@@ -1,0 +1,127 @@
+module Fastlane::Actions
+  describe 'TestplansFromSchemeAction' do
+    describe '::available_options' do
+      it 'raises an error if there is no :xcodeproj or :workspace' do
+        fastfile = "lane :test do
+          testplans_from_scheme(
+            xcodeproj: 'path/to/non-existent.xcodeproj',
+            scheme: 'Oz'
+          )
+        end"
+
+        expect { Fastlane::FastFile.new.parse(fastfile).runner.execute(:test) }.to(
+          raise_error(FastlaneCore::Interface::FastlaneError) do |error|
+            expect(error.message).to match(%r{Error: Xcode project '.*path/to/non-existent.xcodeproj' not found!})
+          end
+        )
+
+        fastfile = "lane :test do
+          testplans_from_scheme(
+            workspace: 'path/to/non-existent.xcworkspace',
+            scheme: 'Oz'
+          )
+        end"
+
+        expect { Fastlane::FastFile.new.parse(fastfile).runner.execute(:test) }.to(
+          raise_error(FastlaneCore::Interface::FastlaneError) do |error|
+            expect(error.message).to match(%r{Error: Workspace file not found at path '.*path/to/non-existent.xcworkspace'})
+          end
+        )
+      end
+      it 'raises an error if the scheme is empty' do
+        allow(Dir).to receive(:exist?).with(%r{.*path/to/non-existent.xcworkspace}).and_return(true)
+        fastfile = "lane :test do
+          testplans_from_scheme(
+            workspace: 'path/to/non-existent.xcworkspace',
+            scheme: ''
+          )
+        end"
+
+        expect { Fastlane::FastFile.new.parse(fastfile).runner.execute(:test) }.to(
+          raise_error(FastlaneCore::Interface::FastlaneError) do |error|
+            expect(error.message).to match("Error: Xcode Scheme '' is not valid!")
+          end
+        )
+      end
+    end
+
+    describe ':run' do
+      it 'raises an error if the given scheme does not exist' do
+        allow(Dir).to receive(:exist?).with(%r{.*path/to/pony.xcworkspace}).and_return(true)
+        fastfile = "lane :test do
+          testplans_from_scheme(
+            workspace: 'path/to/pony.xcworkspace',
+            scheme: 'HappyHelper'
+          )
+        end"
+        expect { Fastlane::FastFile.new.parse(fastfile).runner.execute(:test) }.to(
+          raise_error(FastlaneCore::Interface::FastlaneError) do |error|
+            expect(error.message).to match("Error: cannot find any schemes in the Xcode workspace")
+          end
+        )
+      end
+      it 'returns a list of testplans if some exist' do
+        allow(Dir).to receive(:exist?).with(%r{.*path/to/pony.xcworkspace}).and_return(true)
+        fastfile = "lane :test do
+          testplans_from_scheme(
+            workspace: 'path/to/pony.xcworkspace',
+            scheme: 'HappyHelper'
+          )
+        end"
+        mock_scheme_filepaths = [
+          'path/to/TestProject.xcodeproj/HappyHelper.xcscheme'
+        ]
+        allow(Fastlane::Actions::TestplansFromSchemeAction).to receive(:schemes_from_project).and_return(mock_scheme_filepaths)
+        mock_scheme = OpenStruct.new
+        allow(Xcodeproj::XCScheme).to receive(:new).and_return(mock_scheme)
+        mock_test_action = OpenStruct.new(
+          testables: [
+            OpenStruct.new(
+              buildable_references: [
+                OpenStruct.new(
+                  target_referenced_container: 'container:TestProject.xcodeproj'
+                )
+              ]
+            )
+          ]
+        )
+        allow(mock_scheme).to receive(:test_action).and_return(mock_test_action)
+        mock_test_plans = [
+          OpenStruct.new(
+            target_referenced_container: 'container:testPlan1.xctestplan'
+          ),
+          OpenStruct.new(
+            target_referenced_container: 'container:OldTestPlans/testPlan2.xctestplan'
+          )
+        ]
+        allow(mock_test_action).to receive(:test_plans).and_return(mock_test_plans)
+        result = Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
+        expect(result[0]).to match(%r{path/to/testPlan1.xctestplan})
+        expect(result[1]).to match(%r{path/to/OldTestPlans/testPlan2.xctestplan})
+      end
+
+      it 'returns an empty list if no testplans exist' do
+        allow(Dir).to receive(:exist?).with(%r{.*path/to/pony.xcworkspace}).and_return(true)
+        fastfile = "lane :test do
+          testplans_from_scheme(
+            workspace: 'path/to/pony.xcworkspace',
+            scheme: 'HappyHelper'
+          )
+        end"
+        mock_scheme_filepaths = [
+          'path/to/HappyHelper.xcscheme'
+        ]
+        allow(Fastlane::Actions::TestplansFromSchemeAction).to receive(:schemes_from_project).and_return(mock_scheme_filepaths)
+        mock_scheme = OpenStruct.new
+        allow(Xcodeproj::XCScheme).to receive(:new).and_return(mock_scheme)
+        mock_test_action = OpenStruct.new
+        allow(mock_scheme).to receive(:test_action).and_return(mock_test_action)
+        mock_test_plans = []
+        allow(mock_test_action).to receive(:test_plans).and_return(mock_test_plans)
+        result = Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
+        expect(result).to eq([])
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

As reported in #221 , if the `:testplan` option is presented to `multi_scan`, and it needs to build, it will pass that option to `xcodebuild build-for-testing` and that will cause `xcodebuild` to fail with an error that those options are conflicting.

### Description
<!-- Describe your changes in detail -->

Remove `:testplan` option from the build command.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
