### PR TITLE
issue-225 disable '-quiet' and 'try_count' < 0

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,12 +13,9 @@ end
 lane :testing do
   multi_scan(
     workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
-    scheme: 'AtomicBoy',
-    skip_testing: ["AtomicBoyUITests/AtomicBoyUITests/testExample11"],
-    try_count: 3,
-    output_types: 'xcresult',
-    output_files: 'result.xcresult',
+    scheme: 'Professor',
+    try_count: 0,
     fail_build: false,
-    destination: 'platform=iOS Simulator,name=iPhone 8,OS=13.3'
+    xcargs: '-quiet'
   )
 end

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -14,6 +14,10 @@ module Fastlane
     class MultiScanAction < Action
       def self.run(params)
         params[:quit_simulators] = params._values[:force_quit_simulator] if params._values[:force_quit_simulator]
+        if params[:try_count] < 1
+          UI.important('multi_scan will not test any if :try_count < 0, setting to 1')
+          params[:try_count] = 1
+        end
 
         strip_leading_and_trailing_whitespace_from_output_types(params)
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -93,6 +93,10 @@ module TestCenter
             FastlaneCore::UI.important(":xcargs, #{xcargs}, contained 'build-for-testing', removing it")
             xcargs.slice!('build-for-testing')
           end
+          if xcargs.include?('-quiet')
+            FastlaneCore::UI.important('Disabling -quiet as failing tests cannot be found with it enabled.')
+            xcargs.gsub!('-quiet', '')
+          end
           xcargs.gsub!(/-parallel-testing-enabled(=|\s+)(YES|NO)/, '')
           retrying_scan_options = @reportnamer.scan_options.merge(
             {


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

As reported in #225, using the `-quiet` flag in the `:xcargs` parameter will prevent tests from being reported: this causes `:multi_scan` to _not_ retry tests.

Setting `:try_count` to a value less than 0 will cause `multi_scan` to not try _any_ tests. 

### Description
<!-- Describe your changes in detail -->

Remove the '-quiet' flag with a warning and pin `:try_count` to a mininum of 1.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
