### PR TITLE
Set result extension based on Xcode version

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -346,15 +346,17 @@ module TestCenter
         def move_test_result_bundle_for_next_run
           return unless @options[:result_bundle]
 
-          glob_pattern = "#{output_directory}/*.test_result"
+          result_extension = FastlaneCore::Helper.xcode_at_least?(11) ? '.xcresult' : '.test_result'
+          
+          glob_pattern = "#{output_directory}/*#{result_extension}"
           preexisting_test_result_bundles = Dir.glob(glob_pattern)
           unnumbered_test_result_bundles = preexisting_test_result_bundles.reject do |test_result|
-            test_result =~ /.*-\d+\.test_result/
+            test_result =~ /.*-\d+\#{result_extension}/
           end
           src_test_bundle = unnumbered_test_result_bundles.first
           dst_test_bundle_parent_dir = File.dirname(src_test_bundle)
-          dst_test_bundle_basename = File.basename(src_test_bundle, '.test_result')
-          dst_test_bundle = "#{dst_test_bundle_parent_dir}/#{dst_test_bundle_basename}-#{@testrun_count}.test_result"
+          dst_test_bundle_basename = File.basename(src_test_bundle, result_extension)
+          dst_test_bundle = "#{dst_test_bundle_parent_dir}/#{dst_test_bundle_basename}-#{@testrun_count}#{result_extension}"
           FastlaneCore::UI.verbose("Moving test_result '#{src_test_bundle}' to '#{dst_test_bundle}'")
           File.rename(src_test_bundle, dst_test_bundle)
         end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

`fastlane/scan` changed the extension based on Xcode version: fastlane/fastlane#16044

Fixes #228 

### Description
<!-- Describe your changes in detail -->

- Added a check for Xcode version and set the extension based on that

TODO: tests?

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
