### PR TITLE
issue-232 refine xctestrun glob for testplans

### DIFF
--- a/AtomicBoy/AtomicBoy.xcworkspace/contents.xcworkspacedata
+++ b/AtomicBoy/AtomicBoy.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:SuperAtomicBoy_2.xctestplan">
+   </FileRef>
+   <FileRef
       location = "group:AtomicBoy_2.xctestplan">
    </FileRef>
    <FileRef

--- a/AtomicBoy/SuperAtomicBoy_2.xctestplan
+++ b/AtomicBoy/SuperAtomicBoy_2.xctestplan
@@ -1,0 +1,18 @@
+{
+  "configurations" : [
+    {
+      "id" : "328D2A51-5105-4E7C-B0C3-8B58364EB83D",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+
+  ],
+  "version" : 1
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,20 +10,12 @@ lane :run_examples do
   end
 end
 
-lane :testplan do
-  puts test_options_from_testplan(
-    workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
-    scheme: 'AtomicBoy',
-    testplan: 'AtomicBoy_2'
-  )
-end
-
 lane :testing do
   multi_scan(
     workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
     scheme: 'AtomicBoy',
-    testplan: 'AtomicBoy_2',
     try_count: 3,
-    fail_build: false
+    fail_build: false,
+    testplan: 'AtomicBoy_2'
   )
 end

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -246,7 +246,7 @@ module Fastlane
       def self.update_xctestrun_after_build(scan_options)
         glob_pattern = "#{Scan.config[:derived_data_path]}/Build/Products/*.xctestrun"
         if scan_options[:testplan]
-          glob_pattern = "#{Scan.config[:derived_data_path]}/Build/Products/*#{scan_options[:testplan]}*.xctestrun"
+          glob_pattern = "#{Scan.config[:derived_data_path]}/Build/Products/*_#{scan_options[:testplan]}_*.xctestrun"
         end
         xctestrun_files = Dir.glob(glob_pattern)
         UI.verbose("After building, found xctestrun files #{xctestrun_files} (choosing 1st)")


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes #232 where the wrong test plan is used to run tests. 

### Description
<!-- Describe your changes in detail -->

This refine the shell glob used to find the `xctestrun` bundle associated with the given `:testplan`.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
