### PR TITLE
issue-230 fix not found xcresult crash

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -224,8 +224,10 @@ module TestCenter
           src_xcresult_bundlepath = File.join(testable_output_dir, xcresult_bundlename)
           dst_xcresult_bundlepath = File.join(final_output_dir, xcresult_bundlename)
 
-          # We do not need to merge if one of these do not exist
-          return unless File.exist?(src_xcresult_bundlepath) || File.exist?(dst_xcresult_bundlepath)
+          # if there is no destination bundle to merge to, skip it as any source bundle will be copied when complete.
+          return if !File.exist?(dst_xcresult_bundlepath)
+          # if there is no source bundle to merge, skip it as there is nothing to merge.
+          return if !File.exist?(src_xcresult_bundlepath)
 
           config = FastlaneCore::Configuration.create(
             Fastlane::Actions::CollateXcresultsAction.available_options,


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes #230 which crashes when there is no xcresult file to merge from or into.

### Description
<!-- Describe your changes in detail -->

Exit from the merge if there is either no destination xcresult bundle to merge into, or there is no source xcresult bundle to merge from.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
