### PR TITLE
issue-237 fix test retrieval from testplans

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/test_options_from_testplan.rb
+++ b/lib/fastlane/plugin/test_center/actions/test_options_from_testplan.rb
@@ -14,6 +14,7 @@ module Fastlane
           if test_target.key?('selectedTests')
             UI.verbose("  Found selectedTests")
             test_identifiers = test_target['selectedTests'].each do |selected_test|
+              selected_test.delete!('()')
               UI.verbose("    Found test: '#{selected_test}'")
               only_testing << "#{testable}/#{selected_test.sub('\/', '/')}"
             end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Issue #237 demonstrates that Swift tests from a testplan are not correctly retrieved. This causes a failure in `multi_scan` when it tries to determine which tests to retry and it ends up retrying all tests.

### Description
<!-- Describe your changes in detail -->

Remove the `()` from Swift tests when collecting them from a testplan.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
