### PR TITLE
Fix issue with workspace schemes and testplans

### DIFF
--- a/spec/testplans_from_scheme_spec.rb
+++ b/spec/testplans_from_scheme_spec.rb
@@ -56,7 +56,7 @@ module Fastlane::Actions
         end"
         expect { Fastlane::FastFile.new.parse(fastfile).runner.execute(:test) }.to(
           raise_error(FastlaneCore::Interface::FastlaneError) do |error|
-            expect(error.message).to match("Error: cannot find any schemes in the Xcode workspace")
+            expect(error.message).to match("Error: cannot find any schemes named 'HappyHelper' in the Xcode workspace")
           end
         )
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

When Xcode Schemes are stored inside the Workspace, an error occurs when trying to construct the file path to the testplans as per #231.

### Description
<!-- Describe your changes in detail -->

1. Change the path to the "container" to allow it to be inside a `xcworkspace` or an `xcodeproj`.
1. Update code to get Schemes to first look inside the workspace when that option is given.
1. Update code to only look at projects referenced by a workspace when workspace is the given option.
1. Refactor `testplans_from_scheme.rb` into smaller methods.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
