### PR TITLE
issue-216 clone all desired sims for parallel runs

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/simulator_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/simulator_helper.rb
@@ -12,34 +12,43 @@ module TestCenter
           end
         end
 
+        def simulator_matches_destination(simulator, destination)
+          match = destination.match(/id=(?<udid>[^,]+)/)
+          if match
+            found_match = (match[:udid] == simulator.udid)
+          else
+            match = destination.match(/name=(?<name>[^,]+)/)
+            name = match[:name] || ''
+            match = destination.match(/OS=(?<os_version>[^,]+)/)
+            os_version = match[:os_version] || ''
+
+            found_match = (name == simulator.name && os_version == simulator.os_version)
+          end
+          found_match
+        end
+
         def clone_destination_simulators
           cloned_simulators = []
 
           run_count = @options[:parallel_testrun_count] || 0
+          destinations = Scan.config[:destination].clone
           original_simulators = FastlaneCore::DeviceManager.simulators('iOS').find_all do |simulator|
-            found_match = false
-            Scan.config[:destination].each do |destination|
-              match = destination.match(/id=(?<udid>[^,]+)/)
-              if match
-                found_match = (match[:udid] == simulator.udid)
-              else
-                match = destination.match(/name=(?<name>[^,]+)/)
-                name = match[:name] || ''
-                match = destination.match(/OS=(?<os_version>[^,]+)/)
-                os_version = match[:os_version] || ''
-
-                found_match = (name == simulator.name && os_version == simulator.os_version)
-              end
+            found_simulator = destinations.find do |destination|
+              simulator_matches_destination(simulator, destination)
             end
-            found_match
+            if found_simulator
+              destinations.delete(found_simulator)
+            end
+
+            !found_simulator.nil?
           end
           original_simulators.each(&:shutdown)
           (0...run_count).each do |batch_index|
             cloned_simulators << []
             original_simulators.each do |simulator|
-              FastlaneCore::UI.verbose("Cloning simulator")
               cloned_simulator = simulator.clone
               new_first_name = simulator.name.sub(/( ?\(.*| ?$)/, " Clone #{batch_index + 1}")
+              FastlaneCore::UI.verbose("Cloned simulator #{simulator.name} to (name=#{new_first_name}, udid=#{cloned_simulator.udid}, OS=#{cloned_simulator.ios_version})")
               new_last_name = "#{self.class.name}<#{self.object_id}>"
               cloned_simulator.rename("#{new_first_name} #{new_last_name}")
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

As per #216, when devs state that they want multiple simulators tested, multi-scan only scans on one of the devices when running tests in parallel.

### Description
<!-- Describe your changes in detail -->

1. Stop looping through the list of requested sims when filtering through all the devices.
1. When one is found, we can remove the found device from the list and look for the next one.
1. Refactor the match checking code into its own method.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
