### PR TITLE
Add test for issue-232 multi-destination sims

### DIFF
--- a/spec/multi_scan_manager/simulator_helper_spec.rb
+++ b/spec/multi_scan_manager/simulator_helper_spec.rb
@@ -104,6 +104,26 @@ module TestCenter::Helper::MultiScanManager
         result = helper.clone_destination_simulators
         expect(result).to eq(cloned_simulators.map { |s| [ s ] })
       end
+
+      it 'creates multiple cloned simulators for each batch' do
+        @mocked_scan_config[:destination] = @mocked_scan_config[:destination] << 'platform=iOS Simulator,id=C3C9E104-8A3C-4BD0-9285-2112D3F783FA'
+        allow(::Scan).to receive(:config).and_return(@mocked_scan_config)
+        @mocked_simulators.each do |mocked_simulator|
+          allow(mocked_simulator).to receive(:rename)
+        end
+
+        helper = SimulatorHelper.new(
+          derived_data_path: 'AtomicBoy-flqqvvvzbouqymbyffgdbtjoiufr',
+          project: File.absolute_path('AtomicBoy/AtomicBoy.xcodeproj'),
+          scheme: 'Atlas',
+          parallel_testrun_count: 2,
+          pre_delete_cloned_simulators: false
+        )
+        cloned_simulators = helper.clone_destination_simulators
+        expect(cloned_simulators[0].size).to eq(2)
+        expect(cloned_simulators[1].size).to eq(2)
+      end
+
     end
   end
 end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Adds a test to make sure that when parallel test runs are chosen, and multiple destinations for simulator tests, `multi_scan` clones all the destinations for each test run.

### Description
<!-- Describe your changes in detail -->

Add the test to make sure that all destinations are cloned.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
