### PR TITLE
issue-243 fix testplans w sim log collection

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -232,7 +232,7 @@ module Fastlane
       end
 
       def self.prepare_scan_options_for_build_for_testing(scan_options)
-        build_options = scan_options.merge(build_for_testing: true).reject { |k| %i[test_without_building, testplan, include_simulator_logs].include?(k) }
+        build_options = scan_options.merge(build_for_testing: true).reject { |k| %i[test_without_building testplan include_simulator_logs].include?(k) }
         Scan.config = FastlaneCore::Configuration.create(
           Fastlane::Actions::ScanAction.available_options,
           ScanHelper.scan_options_from_multi_scan_options(build_options)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes Issue #243 where testplans are not being found again.

### Description
<!-- Describe your changes in detail -->

Use the `%i[]` symbol array creation correctly.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
