### PR TITLE
issue-250 fix collate crash w/ no failure details

### DIFF
--- a/spec/fixtures/report-6.html
+++ b/spec/fixtures/report-6.html
@@ -111,9 +111,9 @@
       <section class="right">
         <section id="counters">
           <h2 id="test-count"><span class="number">4</span> tests</h2>
-          
+
           <h2 id="fail-count"><span class="number">4</span> failures</h2>
-          
+
         </section>
         <section id="segment-bar">
           <a id="all-segment" onclick="selectSegment(this);" class="selected">All</a><a id="failing-segment" onclick="selectSegment(this);">Failing</a><a id="passing-segment" onclick="selectSegment(this);">Passing</a>
@@ -121,127 +121,104 @@
       </section>
     </header>
     <section id="test-suites">
-      
-        
+
+
         <section class="test-suite failing" id="AtomicBoyUITests">
           <section class="heading" onclick="toggleTests(this);">
             <h3 class="title">AtomicBoyUITests</h3>
           </section>
           <section class="tests">
             <table>
-            
+
               <tr class="test failing odd"  onclick="toggleDetails('testExample2');">
                 <td>
-                  
+
                 </td>
                 <td><h3 class="title">testExample2</h3></td>
               </tr>
-              
+
                 <tr class="details failing testExample2">
                   <td></td>
                   <td>
-                    
+
                       <section class="test-detail reason">((false) is true) failed</section>
-                    
-                    
+
+
                       <section class="test-detail snippet"></section>
                       <section class="test-detail">AtomicBoyUITests.m:48</section>
-                    
-                    
+
+
                   </td>
                 </tr>
 
               <tr class="test failing "  onclick="toggleDetails('testExample');">
                 <td>
-                  
+
                 </td>
                 <td><h3 class="title">testExample</h3></td>
               </tr>
-              
+
                 <tr class="details failing testExample">
                   <td></td>
                   <td>
-                    
+
                       <section class="test-detail reason">((false) is true) failed</section>
-                    
-                    
+
+
                       <section class="test-detail snippet"></section>
                       <section class="test-detail">AtomicBoyUITests.m:40</section>
-                    
-                    
+
+
                   </td>
                 </tr>
-              
-            
-              
-              <tr class="test failing odd"  onclick="toggleDetails('testExample');">
-                <td>
-                  
-                </td>
-                <td><h3 class="title">testExample</h3></td>
-              </tr>
-              
-              <tr class="test failing odd"  onclick="toggleDetails('testExample');">
+
+
+
+              <tr class="test passing odd"  onclick="toggleDetails('testExample');">
                 <td>
 
                 </td>
                 <td><h3 class="title">testExample</h3></td>
               </tr>
-
-                <tr class="details failing testExample">
-                  <td></td>
-                  <td>
-                    
-                      <section class="test-detail reason">((false) is true) failed</section>
-                    
-                    
-                      <section class="test-detail snippet"></section>
-                      <section class="test-detail">AtomicBoyUITests.m:48</section>
-                    
-                    
-                  </td>
-                </tr>
-              
-            
             </table>
           </section>
         </section>
-      
-        
+
+
         <section class="test-suite failing" id="AtomicBoyUITests.SwiftAtomicBoyUITests">
           <section class="heading" onclick="toggleTests(this);">
             <h3 class="title">AtomicBoyUITests.SwiftAtomicBoyUITests</h3>
           </section>
           <section class="tests">
             <table>
-            
-              
+
+
               <tr class="test failing "  onclick="toggleDetails('testExample');">
                 <td>
-                  
+
                 </td>
                 <td><h3 class="title">testExample</h3></td>
               </tr>
-              
+
                 <tr class="details failing testExample">
                   <td></td>
                   <td>
-                    
+
                       <section class="test-detail reason">XCTAssertTrue failed - </section>
-                    
-                    
+
+
                       <section class="test-detail snippet"></section>
                       <section class="test-detail">SwiftAtomicBoyUITests.swift:14</section>
-                    
-                    
+
+
                   </td>
                 </tr>
-              
-            
+
+
             </table>
           </section>
         </section>
-      
+
     </section>
     <footer>Report generated with <a href="https://github.com/supermarin/xcpretty">xcpretty</a></footer>
   </body>

--- a/spec/html_test_report_spec.rb
+++ b/spec/html_test_report_spec.rb
@@ -210,6 +210,14 @@ module TestCenter::Helper::HtmlTestReport
           testcases_titles = testsuite_1.testcases.map(&:title)
           expect(testcases_titles).to eq(["testExample2", "testExample"])
         end
+
+        it 'removes failing duplicate testcases' do
+          html_report = Report.new(REXML::Document.new(File.new(File.open('./spec/fixtures/report-6.html'))))
+          testsuite_1 = html_report.testsuites[0]
+          testsuite_1.remove_duplicate_testcases
+          testcases_passings = testsuite_1.testcases.map(&:passing?)
+          expect(testcases_passings).to eq([false, true])
+        end
       end
 
       describe '#collate_testsuite' do


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Issue #250 describes a crash when collating HTML reports and, for some reason, the failure details of a failing test is missing.

### Description
<!-- Describe your changes in detail -->

1. Only delete the failure details element if it exists
2. Favor deleting failing duplicated testcases over passing duplicated testcases
3. Add rspec tests for handling missing failure details and ensuring that failing duplicated testcases are deleted first.


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
