### PR TITLE
issue-250 fix older fastlane sim log collection

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -235,7 +235,7 @@ module Fastlane
         build_options = scan_options.merge(build_for_testing: true).reject { |k| %i[test_without_building testplan include_simulator_logs].include?(k) }
         Scan.config = FastlaneCore::Configuration.create(
           Fastlane::Actions::ScanAction.available_options,
-          ScanHelper.scan_options_from_multi_scan_options(build_options)
+          ScanHelper.scan_options_from_multi_scan_options(build_options).merge(include_simulator_logs: false)
         )
         values = Scan.config.values(ask: false)
         values[:xcode_path] = File.expand_path("../..", FastlaneCore::Helper.xcode_path)

--- a/lib/fastlane/plugin/test_center/helper/fastlane_core/device_manager/simulator_extensions.rb
+++ b/lib/fastlane/plugin/test_center/helper/fastlane_core/device_manager/simulator_extensions.rb
@@ -1,0 +1,16 @@
+
+module FixedCopyLogarchiveFastlaneSimulator
+  def self.included(base)
+    base.instance_eval do
+      def copy_logarchive(device, log_identity, logs_destination_dir)
+        require 'shellwords'
+
+        logarchive_dst = File.join(logs_destination_dir, "system_logs-#{log_identity}.logarchive")
+        FileUtils.rm_rf(logarchive_dst)
+        FileUtils.mkdir_p(File.expand_path("..", logarchive_dst))
+        command = "xcrun simctl spawn #{device.udid} log collect --output #{logarchive_dst.shellescape} 2>/dev/null"
+        FastlaneCore::CommandExecutor.execute(command: command, print_all: false, print_command: true)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/test_center/helper/fastlane_core/device_manager/simulator_extensions.rb
+++ b/lib/fastlane/plugin/test_center/helper/fastlane_core/device_manager/simulator_extensions.rb
@@ -4,7 +4,7 @@ module FixedCopyLogarchiveFastlaneSimulator
     base.instance_eval do
       def copy_logarchive(device, log_identity, logs_destination_dir)
         require 'shellwords'
-
+        FastlaneCore::UI.verbose("> FixedCopyLogarchiveFastlaneSimulator.copy_logarchive")
         logarchive_dst = File.join(logs_destination_dir, "system_logs-#{log_identity}.logarchive")
         FileUtils.rm_rf(logarchive_dst)
         FileUtils.mkdir_p(File.expand_path("..", logarchive_dst))

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/device_manager.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/device_manager.rb
@@ -19,7 +19,7 @@ module FastlaneCore
       end
 
       def boot
-        `xcrun simctl boot #{self.udid}`
+        `xcrun simctl boot #{self.udid}` unless self.state == "Booted"
       end
 
       def shutdown

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -345,7 +345,7 @@ module TestCenter
             new_logname = "#{batch_prefix}try-#{testrun_count}-#{File.basename(log_filepath)}"
             new_log_filepath = "#{File.dirname(log_filepath)}/#{new_logname}"
             FastlaneCore::UI.verbose("Moving simulator log '#{log_filepath}' to '#{new_log_filepath}'")
-            File.rename(log_filepath, new_log_filepath)
+            FileUtils.mv(log_filepath, new_log_filepath, force: true)
           end
         end
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -23,6 +23,7 @@ module TestCenter
           @batch_count = 1 # default count. Will be updated by setup_testcollector
           setup_testcollector
           setup_logcollection
+          FastlaneCore::UI.verbose("< done in TestCenter::Helper::MultiScanManager.initialize")
         end
 
         def update_options_to_use_xcresult_output
@@ -38,12 +39,14 @@ module TestCenter
         end
 
         def setup_logcollection
+          FastlaneCore::UI.verbose("> setup_logcollection")
           return unless @options[:include_simulator_logs]
-          return unless Scan::Runner.method_defined?(:prelaunch_simulators)
+          return if Scan::Runner.method_defined?(:prelaunch_simulators)
 
           # We need to prelaunch the simulators so xcodebuild
           # doesn't shut it down before we have a chance to get
           # the logs.
+          FastlaneCore::UI.verbose("\t collecting devices to boot for log collection")
           devices_to_shutdown = []
           Scan.devices.each do |device|
             devices_to_shutdown << device if device.state == "Shutdown"
@@ -52,6 +55,7 @@ module TestCenter
           at_exit do
             devices_to_shutdown.each(&:shutdown)
           end
+          FastlaneCore::UI.verbose("\t fixing FastlaneCore::Simulator.copy_logarchive")
           FastlaneCore::Simulator.send(:include, FixedCopyLogarchiveFastlaneSimulator)
         end
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -6,6 +6,7 @@ module TestCenter
       require 'json'
       require 'shellwords'
       require 'snapshot/reset_simulators'
+      require_relative '../fastlane_core/device_manager/simulator_extensions'
 
       class Runner
         attr_reader :retry_total_count
@@ -21,6 +22,7 @@ module TestCenter
           end
           @batch_count = 1 # default count. Will be updated by setup_testcollector
           setup_testcollector
+          setup_logcollection
         end
 
         def update_options_to_use_xcresult_output
@@ -33,6 +35,17 @@ module TestCenter
           @options[:output_types] = updated_output_types
           @options[:output_files] = updated_output_files
           @options.reject! { |k,_| k == :result_bundle }
+        end
+
+        def setup_logcollection
+          return unless @options[:include_simulator_logs]
+          return unless Scan::Runner.method_defined?(:prelaunch_simulators)
+
+          # We need to prelaunch the simulators so xcodebuild
+          # doesn't shut it down before we have a chance to get
+          # the logs.
+          @options[:prelaunch_simulator] = true
+          FastlaneCore::Simulator.send(:include, FixedCopyLogarchiveFastlaneSimulator)
         end
 
         def setup_testcollector


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This address Issue #248 where the simulators are being retrieved from a simulator that has not run the tests. There is a [fastlane PR 16833](https://github.com/fastlane/fastlane/pull/16833) open, but this fix should be available for older versions of fastlane.

### Description
<!-- Describe your changes in detail -->

If the `FastlaneCore::Simulator` class does not have the `:prelaunch_simulators` method, we patch it with a fixed copy of the method.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
