### PR TITLE
issue-254 improve batch and parallel testrun logic

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,15 +14,14 @@ lane :testing do
   multi_scan(
     workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
     scheme: 'AtomicBoy',
-    try_count: 3,
     buildlog_path: "logs/scan/",
     derived_data_path: "DerivedData",
     fail_build: false,
-    result_bundle: true,
-    batch_count: 1,
-    quit_simulators: true,
     include_simulator_logs: true,
+    device: "iPhone 8",
+    try_count: 2,
+    batch_count: 1,
     parallel_testrun_count: 4,
-    device: "iPhone 8"
+    only_testing: ['AtomicBoyUITests/AtomicBoyUITests/testExample3']
   )
 end

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -42,6 +42,10 @@ module TestCenter
           @test_collector = TestCollector.new(@options)
           @options.reject! { |key| %i[testplan].include?(key) }
           @batch_count = @test_collector.test_batches.size
+          if @test_collector.test_batches.flatten.size < @options[:parallel_testrun_count].to_i
+            FastlaneCore::UI.important(":parallel_testrun_count greater than the number of tests (#{@test_collector.only_testing.size}). Reducing to that number.")
+            @options[:parallel_testrun_count] = @test_collector.only_testing.size
+          end
         end
 
         def output_directory(batch_index = 0, test_batch = [])
@@ -182,11 +186,21 @@ module TestCenter
         end
 
         def scan_options_for_worker(test_batch, batch_index)
+          if @test_collector.test_batches.size > 1
+            # If there are more than 1 batch, then we want each batch result
+            # sent to a "batch index" output folder to be collated later
+            # into the requested output_folder.
+            # Otherwise, send the results from the one and only one batch
+            # to the requested output_folder
+            batch_index += 1
+            batch = batch_index
+          end
+
           {
             only_testing: test_batch.map(&:shellsafe_testidentifier),
-            output_directory: output_directory(batch_index + 1, test_batch),
+            output_directory: output_directory(batch_index, test_batch),
             try_count: @options[:try_count],
-            batch: batch_index + 1
+            batch: batch
           }
         end
 

--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -6,6 +6,7 @@ module TestCenter
 
     class TestCollector
       attr_reader :xctestrun_path
+      attr_reader :only_testing
 
       def initialize(options)
         unless options[:xctestrun] || options[:derived_data_path]

--- a/spec/multi_scan_manager/runner_spec.rb
+++ b/spec/multi_scan_manager/runner_spec.rb
@@ -5,6 +5,7 @@ module TestCenter::Helper::MultiScanManager
         test_batches: [],
         xctestrun_path: ''
       )
+      allow(@mock_test_collector).to receive(:test_batches).and_return([['MockTest']])
       allow(TestCenter::Helper::TestCollector).to receive(:new).and_return(@mock_test_collector)
       @use_refactored_parallelized_multi_scan = ENV['USE_REFACTORED_PARALLELIZED_MULTI_SCAN']
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

As per issue #254, it was discovered that there were a number of anomalies around how `:multi_scan` handles batches and parallel test runs.

### Description
<!-- Describe your changes in detail -->

This improves the logic around the creation of simulator clones to
account for a reduced number of tests. If there are fewer tests than the
requested parallel_test_runs, reduce the number of simulators to the
number of tests.

Additionally, if there was only 1 batch requested, stop prefixing
results with the batch number and output directly to the requested
output folder.


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
