### PR TITLE
issue-253 No xcresult output_type for scan and better documentation

### DIFF
--- a/docs/feature_details/multi_scan.md
+++ b/docs/feature_details/multi_scan.md
@@ -35,9 +35,16 @@ If you have a large number of tests, and you want to inspect the overall status 
 
 ## Better Results Reporting
 
-Do you have multiple test targets and the normal operation of `:scan` is providing you a test report that implies that all the tests ran in just one test target? Don't worry, `:multi_scan` has fixed that. It will provide a separate test report for each test target. It can handle JUnit, HTML, JSON, and Apple's `test_result` bundles.
+Do you have multiple test targets and the normal operation of `:scan` is providing you a test report that implies that all the tests ran in just one test target? Don't worry, `:multi_scan` has fixed that. It will provide a separate test report for each test target. It can handle JUnit, HTML, JSON, and Apple's `xcresult` bundles.
 
-`test_result` bundles are particularly useful because they contain screenshots of the UI when a UI test fails so you can review what was actually there compared to what you expected.
+`xcresult` bundles are particularly useful because they contain screenshots of the UI when a UI test fails so you can review what was actually there compared to what you expected.
+
+> **Notes about `xcresult` and `result_bundle`**:
+> 1. `multi_scan` adds support for `xcresult` as an additional `:output_type`. This allows you to name your `xcresult` files using the `:output_files` parameter (`scan` does not support this).
+>
+> 2. If you pass `xcresult` as a type, `multi_scan` will _not_ pass the `result_bundle` parameter down to `scan` to ensure that your chosen name in `output_files` is used.
+>
+> 3. The `result_bundle` option used to provide `.result_bundle` files. `scan` recently changed that file extension to `.xcresult` to match what Apple is naming the file, and this broke builds expecting the `.result_bundle` extension. As a fix, `multi_scan` creates a `.result_bundle` symbolic link to the `.xcresult` bundle.
 
 ****
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,13 +16,10 @@ lane :testing do
     scheme: 'AtomicBoy',
     try_count: 3,
     buildlog_path: "logs/scan/",
+    output_types: " html , junit",
+    output_files: " index.html , report.junit",
     derived_data_path: "DerivedData",
     fail_build: false,
-    result_bundle: true,
-    batch_count: 1,
-    quit_simulators: true,
-    include_simulator_logs: true,
-    parallel_testrun_count: 4,
     device: "iPhone 8"
   )
 end

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -231,8 +231,28 @@ module Fastlane
         scan_options[:derived_data_path] = Scan.config[:derived_data_path]
       end
 
+      def self.remove_xcresult_from_build_options(build_options)
+        # convert the :output_types comma separated string of types into an array with no whitespace
+        output_types = build_options[:output_types].to_s.split(',').map(&:strip)
+        xcresult_index = output_types.index('xcresult')
+
+        unless xcresult_index.nil?
+          output_types.delete_at(xcresult_index)
+          # set :output_types value to comma separated string of remaining output types
+          build_options[:output_types] = output_types.join(',')
+
+          if build_options[:output_files] # not always set
+            output_files = build_options[:output_files].split(',').map(&:strip)
+            output_files.delete_at(xcresult_index)
+
+            build_options[:output_files] = output_files.join(',')
+          end
+        end
+      end
+
       def self.prepare_scan_options_for_build_for_testing(scan_options)
         build_options = scan_options.merge(build_for_testing: true).reject { |k| %i[test_without_building testplan include_simulator_logs].include?(k) }
+        remove_xcresult_from_build_options(build_options)
         Scan.config = FastlaneCore::Configuration.create(
           Fastlane::Actions::ScanAction.available_options,
           ScanHelper.scan_options_from_multi_scan_options(build_options)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This will fix issue #253 in which the `xcresult` `:output_type` is passed down to `scan` and generates a warning. Also clears up some confusion around the feature in the documenation.

### Description
<!-- Describe your changes in detail -->

This strips out the xcresult type (and associated filename) from the
options that are being sent to scan when building.

Also improve the documentation around the `xcresult` output_type option
to explain a little more what it is doing and why multi_scan is _not_
sending down the `result_bundle`, and why a symbolic link is being
created if the `result_bundle` option was chosen.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
