### PR TITLE
issue-252 remove :skip_build from scan options

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,6 +22,7 @@ lane :testing do
     batch_count: 1,
     quit_simulators: true,
     include_simulator_logs: true,
+    skip_build: true,
     parallel_testrun_count: 4,
     device: "iPhone 8"
   )

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -170,8 +170,10 @@ module Fastlane
         reset_scan_config_to_defaults
         use_scanfile_to_override_settings(scan_options)
         turn_off_concurrent_workers(scan_options)
+        UI.important("Turning off :skip_build as it doesn't do anything with multi_scan") if scan_options[:skip_build]
+        scan_options.reject! { |k,v| k == :skip_build }
         ScanHelper.remove_preexisting_simulator_logs(scan_options)
-        if scan_options[:test_without_building] || scan_options[:skip_build]
+        if scan_options[:test_without_building]
           UI.verbose("Preparing Scan config options for multi_scan testing")
           prepare_scan_config(scan_options)
         else

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -73,9 +73,7 @@ module TestCenter
         end
 
         def should_run_tests_through_single_try?
-          should_run_for_invocation_tests = @options[:invocation_based_tests] && @options[:only_testing].nil?
-          should_run_for_skip_build = @options[:skip_build]
-          (should_run_for_invocation_tests || should_run_for_skip_build)
+          @options[:invocation_based_tests] && @options[:only_testing].nil?
         end
 
 

--- a/lib/fastlane/plugin/test_center/helper/scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/scan_helper.rb
@@ -13,7 +13,7 @@ module TestCenter
         )
         # :nocov:
       end
-    
+
       def self.remove_preexisting_simulator_logs(params)
         return unless params[:include_simulator_logs]
     

--- a/spec/multi_scan_manager/runner_spec.rb
+++ b/spec/multi_scan_manager/runner_spec.rb
@@ -132,20 +132,6 @@ module TestCenter::Helper::MultiScanManager
         runner.run
       end
 
-      it 'runs :run_tests_through_single_try when given :skip_build' do
-        runner = Runner.new(
-          {
-            output_directory: './path/to/output/directory',
-            scheme: 'AtomicUITests',
-            try_count: 2,
-            skip_build: true
-          }
-        )
-        expect(runner).to receive(:run_tests_through_single_try)
-        expect(runner).to receive(:run_test_batches)
-        runner.run
-      end
-
       it 'does not run single_try_scan when not appropriate' do
         invocation_runner = Runner.new(
           {


### PR DESCRIPTION
multi_scan does things differently in a way that makes the :skip_build
option extraneous. Stop using it and just set it to false.

<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

As per #252, `multi_scan` is not responding to the `:skip_build` option in a way that make sense.

### Description
<!-- Describe your changes in detail -->

- Remove the special handling of `:skip_build`.
- Remove `:skip_build` as it doesn't make sense in the way that `multi_scan` works.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
