### PR TITLE
issue-261 get correct testable name from xctestrun file

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/tests_from_xctestrun.rb
+++ b/lib/fastlane/plugin/test_center/actions/tests_from_xctestrun.rb
@@ -17,12 +17,14 @@ module Fastlane
         if xctestrun_version == 1
           xctestrun.each do |testable_name, test_target_config|
             next if ignoredTestables.include? testable_name
+            test_target_config['TestableName'] = testable_name
             test_targets << test_target_config
           end
         else
           test_configurations = xctestrun['TestConfigurations']
           test_configurations.each do |configuration|
             configuration['TestTargets'].each do |test_target|
+              test_target['TestableName'] = test_target['BlueprintName']
               test_targets << test_target
             end
           end
@@ -30,7 +32,7 @@ module Fastlane
 
         tests = Hash.new([])
         test_targets.each do |xctestrun_config|
-          testable_name = xctestrun_config['ProductModuleName']
+          testable_name = xctestrun_config['TestableName']
           xctest_path = xctest_bundle_path(xctestrun_rootpath, xctestrun_config)
           test_identifiers = []
           if xctestrun_config.key?('OnlyTestIdentifiers')

--- a/spec/fixtures/fake.xctestrun
+++ b/spec/fixtures/fake.xctestrun
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AtomicBoyTests</key>
+	<key>Atomic Boy Tests</key>
 	<dict>
 		<key>BundleIdentifiersForCrashReportEmphasis</key>
 		<array>

--- a/spec/tests_from_xctestrun_spec.rb
+++ b/spec/tests_from_xctestrun_spec.rb
@@ -47,10 +47,10 @@ describe Fastlane::Actions::TestsFromXctestrunAction do
     end"
     tests = Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
     expect(tests).to include(
-      'AtomicBoyTests' => [
-        'AtomicBoyTests/AtomicBoyTests/testUnit1',
-        'AtomicBoyTests/AtomicBoyTests/testUnit2',
-        'AtomicBoyTests/AtomicBoyTests/testUnit3'
+      'Atomic Boy Tests' => [
+        'Atomic Boy Tests/AtomicBoyTests/testUnit1',
+        'Atomic Boy Tests/AtomicBoyTests/testUnit2',
+        'Atomic Boy Tests/AtomicBoyTests/testUnit3'
       ],
       'AtomicBoyUITests' => [
         'AtomicBoyUITests/AtomicBoyTests/testUI1',
@@ -80,7 +80,7 @@ describe Fastlane::Actions::TestsFromXctestrunAction do
     expect(FastlaneCore::UI).to receive(:error).with(/^No tests found.*/).twice
     expect(FastlaneCore::UI).to receive(:important).with(/^Is the Build Setting, `ENABLE_TESTABILITY` enabled.*/).twice
     tests = Fastlane::FastFile.new.parse(fastfile).runner.execute(:test)
-    expect(tests).to eq({'AtomicBoyTests' => [], 'AtomicBoyUITests' => [] })
+    expect(tests).to eq({'Atomic Boy Tests' => [], 'AtomicBoyUITests' => [] })
   end
 
   it 'returns all the tests in useTestSelectionWhitelist enabled xctestrun file' do

--- a/spec/xctestrun_info_spec.rb
+++ b/spec/xctestrun_info_spec.rb
@@ -15,11 +15,11 @@ module TestCenter::Helper
 
     it 'provides the file path to the app to be tested a non-UI test target' do
       info = XCTestrunInfo.new('./spec/fixtures/fake.xctestrun')
-      expect(info.app_path_for_testable('AtomicBoyTests')).to eq("./spec/fixtures/Debug-iphonesimulator/AtomicBoy.app")
+      expect(info.app_path_for_testable('Atomic Boy Tests')).to eq("./spec/fixtures/Debug-iphonesimulator/AtomicBoy.app")
     end
 
     it 'provides the info plist for the app' do
-      infoplist = XCTestrunInfo.new('./spec/fixtures/fake.xctestrun').app_plist_for_testable('AtomicBoyTests')
+      infoplist = XCTestrunInfo.new('./spec/fixtures/fake.xctestrun').app_plist_for_testable('Atomic Boy Tests')
       expect(infoplist['MinimumOSVersion']).to eq('11.0')
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

Fixes #261 by getting the testable name in a different way.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

### Description
<!-- Describe your changes in detail -->

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
