### PR TITLE
issue-268 fix massive test duplication

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -18,6 +18,8 @@ jobs:
         bundle install
     - name: run basic integration tests
       run: bundle exec fastlane integration_test_basic
+    - name: run basic integration tests with edge cases
+      run: bundle exec fastlane integration_test_basic_edgecase_1
     - name: run parallel testrun integration tests
       run: bundle exec fastlane integration_test_parallel
     - name: run parallel testrun edge cases

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,10 +40,6 @@ Metrics/ModuleLength:
 Naming/VariableNumber:
   Enabled: false
 
-# This is used a lot across the fastlane code base for config files
-Style/MethodMissingSuper:
-  Enabled: false
-
 Style/MissingRespondToMissing:
   Enabled: false
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,6 +29,24 @@ lane :integration_test_basic do
   )
 end
 
+lane :integration_test_basic_edgecase_1 do
+  multi_scan(
+    workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
+    scheme: 'AtomicBoy',
+    fail_build: false,
+    try_count: 2,
+    only_testing: ['AtomicBoyUITests', 'AtomicBoyTests']
+  )
+
+  multi_scan(
+    workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
+    scheme: 'AtomicBoy',
+    fail_build: false,
+    try_count: 2,
+    only_testing: ['AtomicBoyUITests/AtomicBoyUITests']
+  )
+end
+
 lane :integration_test_parallel do
   multi_scan(
     workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -277,6 +277,49 @@ module TestCenter::Helper
           )
           expect(test_collector.test_batches.size).to eq(12)
         end
+
+        it 'expands testsuites to tests correctly' do
+          test_collector = TestCollector.new(
+            xctestrun: 'path/to/fake.xctestrun'
+          )
+          allow(test_collector).to receive(:xctestrun_known_tests).and_return(
+            {
+              'AtomicPuppyUITests' => [
+                'AtomicPuppyUITests/AtomicPuppyUITests/testExample1',
+                'AtomicPuppyUITests/AtomicPuppyUITests/testExample2',
+                'AtomicPuppyUITests/AtomicPuppyUITests/testExample3',
+                'AtomicPuppyUITests/AtomicPuppyUITests/testExample4',
+                'AtomicPuppyUITests/DogBowlUITests/testExample1'
+              ],
+              'PuppyUITests' => [
+                'PuppyUITests/PuppyUITests/testExample1',
+                'PuppyUITests/PuppyUITests/testExample2',
+                'PuppyUITests/PuppyUITests/testExample3',
+                'PuppyUITests/PuppyUITests/testExample4',
+                'PuppyUITests/FrenchPoodleUITests/testXample1'
+              ]
+
+            }
+          )
+          testable_tests = {
+            'AtomicPuppyUITests' => ['AtomicPuppyUITests'],
+            'PuppyUITests' => ['PuppyUITests']
+          }
+
+          resultant_testable_tests = test_collector.expand_testsuites_to_tests(testable_tests)
+          expect(resultant_testable_tests['PuppyUITests']).to eq([
+            'PuppyUITests/PuppyUITests/testExample1',
+            'PuppyUITests/PuppyUITests/testExample2',
+            'PuppyUITests/PuppyUITests/testExample3',
+            'PuppyUITests/PuppyUITests/testExample4'
+          ])
+          expect(resultant_testable_tests['AtomicPuppyUITests']).to eq([
+            'AtomicPuppyUITests/AtomicPuppyUITests/testExample1',
+            'AtomicPuppyUITests/AtomicPuppyUITests/testExample2',
+            'AtomicPuppyUITests/AtomicPuppyUITests/testExample3',
+            'AtomicPuppyUITests/AtomicPuppyUITests/testExample4'
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes issue #268 where the method to expand testsuites into full
test identifiers would include tests that belonged to testsuites with a
name that included other testsuites.

For example: if expanding Foo, it would get tests for Foo, and for
FooBar.

### Description
<!-- Describe your changes in detail -->

- look for the exact suite name in the given testable
- add tests for this specific case


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
