### PR TITLE
Specifically only retry failing tests

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -249,7 +249,7 @@ module TestCenter
               junit: File.absolute_path(report_filepath)
             }
           )
-          @options[:only_testing] = (@options[:only_testing] || []) - Fastlane::Actions::TestsFromJunitAction.run(config).fetch(:passing, Hash.new).map(&:shellsafe_testidentifier)
+          @options[:only_testing] = Fastlane::Actions::TestsFromJunitAction.run(config).fetch(:failing, Hash.new).map(&:shellsafe_testidentifier)
           if @options[:invocation_based_tests]
             @options[:only_testing] = @options[:only_testing].map(&:strip_testcase).uniq
           end

--- a/spec/multi_scan_manager/retrying_scan_helper_spec.rb
+++ b/spec/multi_scan_manager/retrying_scan_helper_spec.rb
@@ -371,7 +371,8 @@ module TestCenter::Helper::MultiScanManager
         allow(File).to receive(:exist?).and_call_original
         allow(File).to receive(:exist?).with(%r{path/to/output/directory/report.junit}).and_return(true)
         allow(Fastlane::Actions::TestsFromJunitAction).to receive(:run).and_return(
-          passing: ['BagOfTests/CoinTossingUITests/testResultIsHeads']
+          passing: ['BagOfTests/CoinTossingUITests/testResultIsHeads'],
+          failing: ['BagOfTests/CoinTossingUITests/testResultIsTails']
         )
         helper.after_testrun(FastlaneCore::Interface::FastlaneTestFailure.new('test failure'))
         expect(helper.scan_options).to include(


### PR DESCRIPTION

<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
Now that we support Quick Swift tests and I've been using this in production for a while, I realized that the logic in the `retrying_scan_helper.rb` for `multi_scan` wasn't correctly picking up which tests to re-run on failures. I narrowed it down to an issue with tests names, and this PR "fixes" the problem by making the tests that are being retried explicitly the list of tests that failed, as opposed to the set difference between the `only_testing` options passed in to `multi_scan` and the passing tests after a run of `multi_scan`.

@lyndsey-ferguson, I'm unsure why the original logic did the set difference instead of just running the failing tests according to the JUnit reporter, so any insight in to this would be appreciated.

### Description
In the case of Swift tests with Quick, the initial lists of tests in `only_testing` will include just the `spec` method (i.e `TestClass/spec`), while the junit list of passing / failing tests will include the explicit test case names that were determined during runtime (since the test cases, for Quick tests, are all derived at runtime and not compile time). This means that the initial `only_testing` options and the `passing` test list will never overlap, and so in the case of any test failure, all tests will be re-run instead of only the failing ones.

A concrete example of the mismatch between `only_testing` and `passing` in my app repo:

```ruby
$> Fastlane::Actions::TestsFromJunitAction.run(config).fetch(:passing, Hash.new).map(&:shellsafe_testidentifier)
=> ["AppUITests/ForgotPasswordUITests/returns_back_to_the_main_screen_after_a_succesful_reset",
 "AppUITests/ForgotPasswordUITests/shows_an_error_when_the_reset_fails",
 "AppUITests/RequestAccountTests/shows_the_request_account_screen_when_Request_Account_link_pressed_and_is_dismissed_when_Done_is_pressed",
 "AppUITests/SessionUITests/prompts_user_for_their_password_if_their_sesison_expired_while_the_app_was_in_the_background",
 "AppUITests/SessionUITests/throws_an_error_if_the_password_is_incorrect"]

$> @options[:only_testing]
=> ["AppUITests/ForgotPasswordUITests/spec", "AppUITests/SessionUITests/spec", "AppUITests/OutdatedAppUITest/spec", "AppUITests/RequestAccountTests/spec"]
```

As you can tell, if we attempt to subtract the `passing` tests according to junit from the `only_testing` flags originally sent through, we will subtract nothing from `only_testing`, causing all tests to be re-run.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
