### PR TITLE
Issue 271 only testing test targets not expanded

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -105,21 +105,6 @@ module TestCenter
         @known_tests
       end
 
-      # The purpose of this method is to expand :only_testing
-      # that has elements that are just the 'testsuite' or
-      # are just the 'testable/testsuite'. We want to take
-      # those and expand them out to the individual testcases.
-      # 'testsuite' => [
-      #   'testable/testsuite/testcase1',
-      # . 'testable/testsuite/testcase2',
-      # . 'testable/testsuite/testcase3'
-      # ]
-      # OR
-      # 'testable/testsuite' => [
-      #   'testable/testsuite/testcase1',
-      # . 'testable/testsuite/testcase2',
-      # . 'testable/testsuite/testcase3'
-      # ]
       def expand_short_testidentifiers_to_tests(testables_tests)
         # Remember, testable_tests is of the format:
         # {

--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -160,7 +160,9 @@ module TestCenter
             testsuite = ''
             if test_components.size == 1
               if test_components[0] == testable
-                testables_tests[testable][index] = all_known_tests[testable]
+                # The following || [] is just in case the user provided multiple
+                # test targets or there are no actual tests found.
+                testables_tests[testable][index] = all_known_tests[testable] || []
                 all_known_tests.delete(testable)
                 next
               end

--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -120,7 +120,7 @@ module TestCenter
       # . 'testable/testsuite/testcase2',
       # . 'testable/testsuite/testcase3'
       # ]
-      def expand_testsuites_to_tests(testables_tests)
+      def expand_short_testidentifiers_to_tests(testables_tests)
         # Remember, testable_tests is of the format:
         # {
         #   'testable1' => [
@@ -176,7 +176,7 @@ module TestCenter
         unless @testables_tests
           if @only_testing
             @testables_tests = only_testing_to_testables_tests
-            expand_testsuites_to_tests(@testables_tests)
+            expand_short_testidentifiers_to_tests(@testables_tests)
           else
             @testables_tests = xctestrun_known_tests
             if @skip_testing

--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -159,6 +159,12 @@ module TestCenter
 
             testsuite = ''
             if test_components.size == 1
+              if test_components[0] == testable
+                testables_tests[testable][index] = all_known_tests[testable]
+                all_known_tests.delete(testable)
+                next
+              end
+
               testsuite = test_components[0]
             else
               testsuite = test_components[1]

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -345,7 +345,7 @@ module TestCenter::Helper
             }
           )
           testable_tests = {
-            'AtomicPuppyUITests' => ['AtomicPuppyUITests'],
+            'AtomicPuppyUITests' => ['AtomicPuppyUITests', 'AtomicPuppyUITests'],
             'AtomicKittyUITests' => ['AtomicKittyUITests']
           }
 

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -285,39 +285,39 @@ module TestCenter::Helper
           allow(test_collector).to receive(:xctestrun_known_tests).and_return(
             {
               'AtomicPuppyUITests' => [
-                'AtomicPuppyUITests/AtomicPuppyUITests/testExample1',
-                'AtomicPuppyUITests/AtomicPuppyUITests/testExample2',
-                'AtomicPuppyUITests/AtomicPuppyUITests/testExample3',
-                'AtomicPuppyUITests/AtomicPuppyUITests/testExample4',
+                'AtomicPuppyUITests/PuppyUITests/testExample1',
+                'AtomicPuppyUITests/PuppyUITests/testExample2',
+                'AtomicPuppyUITests/PuppyUITests/testExample3',
+                'AtomicPuppyUITests/PuppyUITests/testExample4',
                 'AtomicPuppyUITests/DogBowlUITests/testExample1'
               ],
-              'PuppyUITests' => [
-                'PuppyUITests/PuppyUITests/testExample1',
-                'PuppyUITests/PuppyUITests/testExample2',
-                'PuppyUITests/PuppyUITests/testExample3',
-                'PuppyUITests/PuppyUITests/testExample4',
-                'PuppyUITests/FrenchPoodleUITests/testXample1'
+              'AtomicKittyUITests' => [
+                'AtomicKittyUITests/KittyUITests/testExample1',
+                'AtomicKittyUITests/KittyUITests/testExample2',
+                'AtomicKittyUITests/KittyUITests/testExample3',
+                'AtomicKittyUITests/KittyUITests/testExample4',
+                'AtomicKittyUITests/FrenchPoodleUITests/testXample1'
               ]
 
             }
           )
           testable_tests = {
-            'AtomicPuppyUITests' => ['AtomicPuppyUITests'],
-            'PuppyUITests' => ['PuppyUITests']
+            'AtomicPuppyUITests' => ['PuppyUITests'],
+            'AtomicKittyUITests' => ['KittyUITests']
           }
 
-          resultant_testable_tests = test_collector.expand_testsuites_to_tests(testable_tests)
-          expect(resultant_testable_tests['PuppyUITests']).to eq([
-            'PuppyUITests/PuppyUITests/testExample1',
-            'PuppyUITests/PuppyUITests/testExample2',
-            'PuppyUITests/PuppyUITests/testExample3',
-            'PuppyUITests/PuppyUITests/testExample4'
+          resultant_testable_tests = test_collector.expand_short_testidentifiers_to_tests(testable_tests)
+          expect(resultant_testable_tests['AtomicKittyUITests']).to eq([
+            'AtomicKittyUITests/KittyUITests/testExample1',
+            'AtomicKittyUITests/KittyUITests/testExample2',
+            'AtomicKittyUITests/KittyUITests/testExample3',
+            'AtomicKittyUITests/KittyUITests/testExample4'
           ])
           expect(resultant_testable_tests['AtomicPuppyUITests']).to eq([
-            'AtomicPuppyUITests/AtomicPuppyUITests/testExample1',
-            'AtomicPuppyUITests/AtomicPuppyUITests/testExample2',
-            'AtomicPuppyUITests/AtomicPuppyUITests/testExample3',
-            'AtomicPuppyUITests/AtomicPuppyUITests/testExample4'
+            'AtomicPuppyUITests/PuppyUITests/testExample1',
+            'AtomicPuppyUITests/PuppyUITests/testExample2',
+            'AtomicPuppyUITests/PuppyUITests/testExample3',
+            'AtomicPuppyUITests/PuppyUITests/testExample4'
           ])
         end
       end

--- a/spec/test_collector_spec.rb
+++ b/spec/test_collector_spec.rb
@@ -320,6 +320,51 @@ module TestCenter::Helper
             'AtomicPuppyUITests/PuppyUITests/testExample4'
           ])
         end
+
+        it 'expands test targets to tests correctly' do
+          test_collector = TestCollector.new(
+            xctestrun: 'path/to/fake.xctestrun'
+          )
+          allow(test_collector).to receive(:xctestrun_known_tests).and_return(
+            {
+              'AtomicPuppyUITests' => [
+                'AtomicPuppyUITests/PuppyUITests/testExample1',
+                'AtomicPuppyUITests/PuppyUITests/testExample2',
+                'AtomicPuppyUITests/PuppyUITests/testExample3',
+                'AtomicPuppyUITests/PuppyUITests/testExample4',
+                'AtomicPuppyUITests/DogBowlUITests/testExample1'
+              ],
+              'AtomicKittyUITests' => [
+                'AtomicKittyUITests/KittyUITests/testExample1',
+                'AtomicKittyUITests/KittyUITests/testExample2',
+                'AtomicKittyUITests/KittyUITests/testExample3',
+                'AtomicKittyUITests/KittyUITests/testExample4',
+                'AtomicKittyUITests/FrenchPoodleUITests/testXample1'
+              ]
+
+            }
+          )
+          testable_tests = {
+            'AtomicPuppyUITests' => ['AtomicPuppyUITests'],
+            'AtomicKittyUITests' => ['AtomicKittyUITests']
+          }
+
+          resultant_testable_tests = test_collector.expand_short_testidentifiers_to_tests(testable_tests)
+          expect(resultant_testable_tests['AtomicKittyUITests']).to eq([
+            'AtomicKittyUITests/KittyUITests/testExample1',
+            'AtomicKittyUITests/KittyUITests/testExample2',
+            'AtomicKittyUITests/KittyUITests/testExample3',
+            'AtomicKittyUITests/KittyUITests/testExample4',
+            'AtomicKittyUITests/FrenchPoodleUITests/testXample1'
+          ])
+          expect(resultant_testable_tests['AtomicPuppyUITests']).to eq([
+            'AtomicPuppyUITests/PuppyUITests/testExample1',
+            'AtomicPuppyUITests/PuppyUITests/testExample2',
+            'AtomicPuppyUITests/PuppyUITests/testExample3',
+            'AtomicPuppyUITests/PuppyUITests/testExample4',
+            'AtomicPuppyUITests/DogBowlUITests/testExample1'
+          ])
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes #271 where providing test targets via `:only_testing` does not expand them out to all the tests in the test target.

### Description
<!-- Describe your changes in detail -->

Add all the tests for a given test target if it is found that the provided identifier matches the test target.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
