### PR TITLE
issue-275 omit disable xcpretty option

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -171,7 +171,10 @@ module Fastlane
         use_scanfile_to_override_settings(scan_options)
         turn_off_concurrent_workers(scan_options)
         UI.important("Turning off :skip_build as it doesn't do anything with multi_scan") if scan_options[:skip_build]
-        scan_options.reject! { |k,v| k == :skip_build }
+        if scan_options[:disable_xcpretty]
+          UI.important("Turning off :disable_xcpretty as xcpretty is needed to generate junit reports for retrying failed tests")
+        end
+        scan_options.reject! { |k,v| %i[skip_build disable_xcpretty].include?(k) }
         ScanHelper.remove_preexisting_simulator_logs(scan_options)
         if scan_options[:test_without_building]
           UI.verbose("Preparing Scan config options for multi_scan testing")
@@ -495,7 +498,8 @@ module Fastlane
             workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
             scheme: 'AtomicBoy',
             fail_build: false,
-            try_count: 2
+            try_count: 2,
+            disable_xcpretty: true
           )
           ",
           "

--- a/spec/multi_scan_spec.rb
+++ b/spec/multi_scan_spec.rb
@@ -21,6 +21,36 @@ module Fastlane::Actions
           }
         )
       end
+
+      it 'does NOT pass down :disable_xcpretty to #prepare_scan_config' do
+        allow(MultiScanAction).to receive(:reset_scan_config_to_defaults)
+        allow(MultiScanAction).to receive(:use_scanfile_to_override_settings)
+        allow(::TestCenter::Helper::ScanHelper).to receive(:remove_preexisting_simulator_logs)
+        expect(MultiScanAction).to receive(:prepare_scan_config) do |options|
+          expect(options).not_to include(:disable_xcpretty)
+        end
+        MultiScanAction.prepare_for_testing(
+          {
+            disable_xcpretty: true,
+            test_without_building: true
+          }
+        )
+      end
+
+      it 'does NOT pass down :disable_xcpretty to #build_for_testing' do
+        allow(MultiScanAction).to receive(:reset_scan_config_to_defaults)
+        allow(MultiScanAction).to receive(:use_scanfile_to_override_settings)
+        allow(::TestCenter::Helper::ScanHelper).to receive(:remove_preexisting_simulator_logs)
+        expect(MultiScanAction).to receive(:build_for_testing) do |options|
+          expect(options).not_to include(:disable_xcpretty)
+        end
+        MultiScanAction.prepare_for_testing(
+          {
+            disable_xcpretty: true
+          }
+        )
+      end
+
     end
 
     describe '#prepare_scan_config' do


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

`scan` provides an option to disable the use of xcpretty. xcpretty is used to generate the junit report files in `multi_scan` and those reports contain the information needed to determine whether or not to retry tests. Without that option, `multi_scan` will crash, as described in #275 .


### Description
<!-- Describe your changes in detail -->

Strip out the `:disable_xcpretty` option from the list of options.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
