### PR TITLE
issue-263 support multiple devices

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker_pool.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker_pool.rb
@@ -89,6 +89,12 @@ module TestCenter
           clones.flatten.each(&:delete)
         end
 
+        def shutdown_cloned_simulators(clones)
+          return if clones.nil?
+
+          clones.flatten.each(&:shutdown)
+        end
+
         def setup_serial_workers
           serial_scan_options = @options.reject { |key| %i[device devices].include?(key) }
           serial_scan_options[:destination] ||= Scan&.config&.fetch(:destination)
@@ -125,6 +131,7 @@ module TestCenter
             busy_workers.map(&:pid).each do |pid|
               Process.wait(pid)
             end
+            shutdown_cloned_simulators(@clones)
             busy_workers.each { |w| w.process_results }
           end
         end

--- a/spec/multi_scan_manager/runner_spec.rb
+++ b/spec/multi_scan_manager/runner_spec.rb
@@ -8,6 +8,10 @@ module TestCenter::Helper::MultiScanManager
       allow(@mock_test_collector).to receive(:batches).and_return([['MockTest']])
       allow(TestCenter::Helper::TestCollector).to receive(:new).and_return(@mock_test_collector)
       @use_refactored_parallelized_multi_scan = ENV['USE_REFACTORED_PARALLELIZED_MULTI_SCAN']
+      mock_scan_config = {
+        destination: ["platform=iOS Simulator,id=194E8418-5B34-4919-978F-50D313EC1086"]
+      }
+      allow(Scan).to receive(:config).and_return(mock_scan_config) 
     end
 
     after(:each) do
@@ -99,10 +103,10 @@ module TestCenter::Helper::MultiScanManager
           {
             output_directory: './path/to/output/directory',
             scheme: 'AtomicUITests',
-            try_count: 1
+            try_count: 1,
+            devices: ['iPhone Phantom']
           }
         )
-
         allow(@xctest_runner).to receive(:setup_testcollector)
         allow(@xctest_runner).to receive(:run_test_batches).and_return(true)
         allow(@xctest_runner).to receive(:run_first_run_of_invocation_based_tests).and_return(true)
@@ -125,7 +129,8 @@ module TestCenter::Helper::MultiScanManager
             output_directory: './path/to/output/directory',
             scheme: 'AtomicUITests',
             try_count: 2,
-            invocation_based_tests: true
+            invocation_based_tests: true,
+            devices: ['iPhone Phantom']
           }
         )
         expect(runner).to receive(:run_tests_through_single_try)
@@ -145,7 +150,8 @@ module TestCenter::Helper::MultiScanManager
               'KiwiTests/SmallBirdTests',
               'KiwiTests/CruddogTests',
               'KiwiTests/KiwiDemoTests'
-            ]
+            ],
+            devices: ['iPhone Phantom']
           }
         )
         expect(invocation_runner).not_to receive(:run_tests_through_single_try)
@@ -166,7 +172,6 @@ module TestCenter::Helper::MultiScanManager
             'KiwiTests/KiwiDemoTests'
           ]
         )
-        allow(Scan).to receive(:config).and_return({ destination: ['iPhone 5s,id=ABCDEFGHIJ']})
         
         runner = Runner.new(
           {

--- a/spec/multi_scan_manager/test_batch_worker_pool_spec.rb
+++ b/spec/multi_scan_manager/test_batch_worker_pool_spec.rb
@@ -225,7 +225,8 @@ module TestCenter::Helper::MultiScanManager
           mocked_workers.each do |w|
             expect(w).to receive(:process_results)
           end
-          
+          expect(pool).to receive(:shutdown_cloned_simulators)
+
           pool.wait_for_all_workers
         end
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [ ] I've read the [Contribution Guidelines][contributing doc]
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This addresses #263 where users would pass in multiple devices for testing, `multi_scan` would test, but would only use the results from the first device to determine whether or not to re-run failed tests.

### Description
<!-- Describe your changes in detail -->

Run the entire set of batches per device.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
