### PR TITLE
issue-291 Use Scan.devices only for ios tests

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -41,6 +41,7 @@ module TestCenter
         def setup_logcollection
           FastlaneCore::UI.verbose("> setup_logcollection")
           return unless @options[:include_simulator_logs]
+          return unless @options[:platform] == :ios_simulator
           return if Scan::Runner.method_defined?(:prelaunch_simulators)
 
           # We need to prelaunch the simulators so xcodebuild

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker_pool.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/test_batch_worker_pool.rb
@@ -63,7 +63,9 @@ module TestCenter
         def parallel_scan_options(worker_index)
           options = @options.reject { |key| %i[device devices].include?(key) }
           options[:destination] = destination_for_worker(worker_index)
-          options[:scan_devices_override] = simulator_devices_for_worker(worker_index)
+          if @options[:platform] == :ios_simulator
+            options[:scan_devices_override] = simulator_devices_for_worker(worker_index)
+          end
           options[:buildlog_path] = buildlog_path_for_worker(worker_index) if @options[:buildlog_path]
           options[:derived_data_path] = derived_data_path_for_worker(worker_index)
           options[:batch_index] = worker_index


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Addresses issue #291 where `multi_scan` attempts to manipulate `Scan.devices` (simulators) for macOS tests. That is invalid, and crashes.

### Description
<!-- Describe your changes in detail -->

Check the platform before working with `Scan.devices`

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
