### PR TITLE
issue-293 fix expansion of test identifiers

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -116,9 +116,9 @@ module TestCenter
             # with their own testCases.
             if all_known_tests[testable].to_a.empty?
               FastlaneCore::UI.verbose("Unable to expand #{testable} to constituent tests")
-              expand_test_identifiers = [testable]
+              expanded_test_identifiers = [testable]
             else
-              expand_test_identifiers = all_known_tests[testable]
+              expanded_test_identifiers = all_known_tests[testable]
             end
           else
             # this is a testable and a test suite, let's expand it out to all of
@@ -131,7 +131,7 @@ module TestCenter
             end
           end
           test_identifiers.delete_at(index)
-          test_identifiers.insert(index, *expand_test_identifiers)
+          test_identifiers.insert(index, *expanded_test_identifiers)
         end
       end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes issue #293 where tests were not found and `multi_scan` exited early.

### Description
<!-- Describe your changes in detail -->

This fixes a typos where the variable name that was used to collect tests was not the variable name used to add the tests to the list of only_testing.


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
