### PR TITLE
issue-291 Fixes macOS tests crash from merge

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -94,7 +94,7 @@ module TestCenter
           if should_run_tests_through_single_try?
             test_results.clear
             setup_run_tests_for_each_device do |device_name|
-              FastlaneCore::UI.message("Single try testing for device '#{device_name}'")
+              FastlaneCore::UI.message("Single try testing for device '#{device_name}'") if device_name
               test_results << run_tests_through_single_try
             end
           end
@@ -103,7 +103,7 @@ module TestCenter
             test_results.clear 
             setup_testcollector
             setup_run_tests_for_each_device do |device_name|
-              FastlaneCore::UI.message("Testing batches for device '#{device_name}'")
+              FastlaneCore::UI.message("Testing batches for device '#{device_name}'") if device_name
               test_results << run_test_batches
             end
           end
@@ -112,6 +112,11 @@ module TestCenter
 
         def setup_run_tests_for_each_device
           original_output_directory = @options.fetch(:output_directory, 'test_results') 
+          unless @options[:platform] == :ios_simulator
+            yield
+            return
+          end
+
           scan_destinations = Scan.config[:destination].clone
           try_count = @options[:try_count]
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes another issue introduced by a merge where `multi_scan` will crash when running macOS tests. See the end of #291 for info regarding the crash. 

### Description
<!-- Describe your changes in detail -->

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
