### PR TITLE
Enhance sims log collection to include start time

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/fastlane_core/device_manager/simulator_extensions.rb
+++ b/lib/fastlane/plugin/test_center/helper/fastlane_core/device_manager/simulator_extensions.rb
@@ -1,6 +1,7 @@
 
 module FixedCopyLogarchiveFastlaneSimulator
   def self.included(base)
+    @@log_collection_start_time = DateTime.now
     base.instance_eval do
       def copy_logarchive(device, log_identity, logs_destination_dir)
         require 'shellwords'
@@ -8,7 +9,11 @@ module FixedCopyLogarchiveFastlaneSimulator
         logarchive_dst = File.join(logs_destination_dir, "system_logs-#{log_identity}.logarchive")
         FileUtils.rm_rf(logarchive_dst)
         FileUtils.mkdir_p(File.expand_path("..", logarchive_dst))
-        command = "xcrun simctl spawn #{device.udid} log collect --output #{logarchive_dst.shellescape} 2>/dev/null"
+
+        logs_collection_start = @@log_collection_start_time.strftime('%Y-%m-%d %H:%M:%S')
+        command = "xcrun simctl spawn #{device.udid} log collect "
+        command << "--start '#{logs_collection_start}' "
+        command << "--output #{logarchive_dst.shellescape} 2>/dev/null"
         FastlaneCore::CommandExecutor.execute(command: command, print_all: false, print_command: true)
       end
     end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

This improves the log_archive patch method for the
FastlaneCore::Simulator class to include a start time from when to start
collecting logs (start of multi_scan session).

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Users of fastlane with a version that does not have the fix to collect logs from a start time will not have that ability in this plugin. This updates that.

### Description
<!-- Describe your changes in detail -->

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
