### PR TITLE
issue-303 multi_scan crash if Scan.devices nil

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
@@ -50,7 +50,11 @@ module TestCenter
           if @options[:scan_devices_override]
             scan_device_names = @options[:scan_devices_override].map { |device| device.name }
             FastlaneCore::UI.verbose("\tSetting Scan.devices to #{scan_device_names}")
-            Scan.devices.replace(@options[:scan_devices_override])
+            if Scan.devices
+              Scan.devices.replace(@options[:scan_devices_override])
+            else
+              Scan.devices = @options[:scan_devices_override]
+            end
           end
         end
 


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes #303 when `Scan.devices` is nil. I really should look into how this becomes nil though. I will after I see if this fixes the issue.

### Description
<!-- Describe your changes in detail -->

Set `Scan.devices` if it is nil, otherwise `replace` the contents.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
