### PR TITLE
issue-299 Support turning off verbose msgs

### DIFF
--- a/docs/feature_details/collate_html_reports.md
+++ b/docs/feature_details/collate_html_reports.md
@@ -2,6 +2,8 @@
 
 Do you have multiple html test reports coming in from different sources and need them combined? Use this action to collate all the tests performed for a given test target into one report file.
 
+> Note: if you want to use `--verbose` to get more detailed logging, but you don't want to see the detailed logging for `collate_html_reports`, set the environment variable `COLLATE_HTML_REPORTS_VERBOSITY` to 0.
+
 <img src="./images/collation.jpg" alt="collate html image" />
 
 ## Example

--- a/docs/feature_details/collate_junit_reports.md
+++ b/docs/feature_details/collate_junit_reports.md
@@ -3,6 +3,8 @@
 
 Do you have multiple junit test reports coming in from different sources and need them combined? Use this action to collate all the tests performed for a given test target into one report file.
 
+> Note: if you want to use `--verbose` to get more detailed logging, but you don't want to see the detailed logging for `collate_junit_reports`, set the environment variable `COLLATE_JUNIT_REPORTS_VERBOSITY` to 0.
+
 ## Example
 
 <!-- collate_junit_reports examples: begin -->

--- a/lib/fastlane/plugin/test_center/helper/html_test_report.rb
+++ b/lib/fastlane/plugin/test_center/helper/html_test_report.rb
@@ -1,6 +1,13 @@
 module TestCenter
   module Helper
     module HtmlTestReport
+
+      def self.verbose(message)
+        return if ENV.fetch('COLLATE_HTML_REPORTS_VERBOSITY', 1).to_i.zero?
+
+        FastlaneCore::UI.verbose(message)
+      end
+
       class Report
         require 'rexml/formatters/transitive'
 
@@ -24,16 +31,16 @@ module TestCenter
         def collate_report(report)
           testsuites.each(&:remove_duplicate_testcases)
           report.testsuites.each(&:remove_duplicate_testcases)
-          FastlaneCore::UI.verbose("TestCenter::Helper::HtmlTestReport::Report.collate_report to report:\n\t#{@root}")
+          HtmlTestReport.verbose("TestCenter::Helper::HtmlTestReport::Report.collate_report to report:\n\t#{@root}")
           report.testsuites.each do |given_testsuite|
             existing_testsuite = testsuite_with_title(given_testsuite.title)
             if existing_testsuite.nil?
-              FastlaneCore::UI.verbose("\tadding testsuite\n\t\t#{given_testsuite}")
+              HtmlTestReport.verbose("\tadding testsuite\n\t\t#{given_testsuite}")
               add_testsuite(given_testsuite)
             else
-              FastlaneCore::UI.verbose("\tcollating testsuite\n\t\t#{given_testsuite.root}")
+              HtmlTestReport.verbose("\tcollating testsuite\n\t\t#{given_testsuite.root}")
               existing_testsuite.collate_testsuite(given_testsuite)
-              FastlaneCore::UI.verbose("\tafter collation exiting testsuite\n\t\t#{existing_testsuite.root}")
+              HtmlTestReport.verbose("\tafter collation exiting testsuite\n\t\t#{existing_testsuite.root}")
             end
           end
           update_test_count
@@ -210,15 +217,15 @@ module TestCenter
           given_testcases.each do |given_testcase|
             existing_testcase = testcase_with_title(given_testcase.title)
             if existing_testcase.nil?
-              FastlaneCore::UI.verbose("\t\tadding testcase\n\t\t\t#{given_testcase.root}")
+              HtmlTestReport.verbose("\t\tadding testcase\n\t\t\t#{given_testcase.root}")
               unless given_testcase.passing?
-                FastlaneCore::UI.verbose("\t\t\twith failure:\n\t\t\t\t#{given_testcase.failure_details}")
+                HtmlTestReport.verbose("\t\t\twith failure:\n\t\t\t\t#{given_testcase.failure_details}")
               end
               add_testcase(given_testcase)
             else
-              FastlaneCore::UI.verbose("\t\tupdating testcase\n\t\t\t#{existing_testcase.root}")
+              HtmlTestReport.verbose("\t\tupdating testcase\n\t\t\t#{existing_testcase.root}")
               unless given_testcase.passing?
-                FastlaneCore::UI.verbose("\t\t\twith failure:\n\t\t\t\t#{given_testcase.failure_details}")
+                HtmlTestReport.verbose("\t\t\twith failure:\n\t\t\t\t#{given_testcase.failure_details}")
               end
               existing_testcase.update_testcase(given_testcase)
             end
@@ -275,7 +282,7 @@ module TestCenter
           color = row_color
           failure = failure_details
           if failure.nil? && !passing?
-            FastlaneCore::UI.error("\t\t\t\tupdating failing test case that does not have failure_details")
+            HtmlTestReport.error("\t\t\t\tupdating failing test case that does not have failure_details")
           end
           parent = @root.parent
 
@@ -283,7 +290,7 @@ module TestCenter
 
           new_failure = testcase.failure_details
           if new_failure && testcase.passing?
-            FastlaneCore::UI.error("\t\t\t\tswapping passing failing test case that _does_have_ failure_details")
+            HtmlTestReport.error("\t\t\t\tswapping passing failing test case that _does_have_ failure_details")
           end
 
           parent.replace_child(@root, testcase.root)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Address #299 .

This allows users to turn off verbose messaging by setting the
environment variables COLLATE_HTML_REPORTS_VERBOSITY=0 and/or
COLLATE_JUNIT_REPORTS_VERBOSITY=0

### Description
<!-- Describe your changes in detail -->

Refactored the calls to the `UI.verbose` method to be class methods that check if the environment variable is set to 1 (default 1) before logging.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
