### PR TITLE
issue-305 only disable parallel testing Xcode10+

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -457,6 +457,14 @@ module Fastlane
             default_value: true
           ),
           FastlaneCore::ConfigItem.new(
+            key: :override_scan_options_block,
+            description: 'A block invoked with a Hash of the scan options that will be used when test run is about to start. This allows your code to modify the arguments that will be sent to scan',
+            optional: true,
+            is_string: false,
+            default_value: nil,
+            type: Proc
+          ),
+          FastlaneCore::ConfigItem.new(
             key: :testrun_completed_block,
             description: 'A block invoked each time a test run completes. When combined with :parallel_testrun_count, will be called separately in each child process. Return a Hash with :continue set to false to stop retrying tests, or :only_testing to change which tests will be run in the next try',
             optional: true,

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
@@ -8,57 +8,6 @@ module TestCenter
         end
 
         # :nocov:
-        def scan_config
-          Scan.config
-        end
-
-        def scan_cache
-          Scan.cache
-        end
-        # :nocov:
-
-        def prepare_scan_config
-          # this allows multi_scan's `destination` option to be picked up by `scan`
-          scan_config._values.delete(:device)
-          ENV.delete('SCAN_DEVICE')
-          scan_config._values.delete(:devices)
-          ENV.delete('SCAN_DEVICES')
-          # this prevents double -resultBundlePath args to xcodebuild
-          if ReportNameHelper.includes_xcresult?(@options[:output_types])
-            scan_config._values.delete(:result_bundle)
-            ENV.delete('SCAN_RESULT_BUNDLE')
-          end
-          scan_config._values.delete(:skip_testing)
-          scan_cache.clear
-        end
-
-        def update_scan_options
-          valid_scan_keys = Fastlane::Actions::ScanAction.available_options.map(&:key)
-          scan_options = @options.select { |k,v| valid_scan_keys.include?(k) }
-                                  .merge(@retrying_scan_helper.scan_options)
-
-          prepare_scan_config
-          scan_options[:build_for_testing] = false
-          scan_options.delete(:skip_testing)
-          FastlaneCore::UI.verbose("retrying_scan #update_scan_options")
-          scan_options.each do |k,v|
-            next if v.nil?
-
-            scan_config.set(k,v) unless v.nil?
-            FastlaneCore::UI.verbose("\tSetting #{k.to_s} to #{v}")
-          end
-          if @options[:scan_devices_override]
-            scan_device_names = @options[:scan_devices_override].map { |device| device.name }
-            FastlaneCore::UI.verbose("\tSetting Scan.devices to #{scan_device_names}")
-            if Scan.devices
-              Scan.devices.replace(@options[:scan_devices_override])
-            else
-              Scan.devices = @options[:scan_devices_override]
-            end
-          end
-        end
-
-        # :nocov:
         def self.run(options)
           RetryingScan.new(options).run
         end
@@ -68,12 +17,6 @@ module TestCenter
           try_count = @options[:try_count] || 1
           begin
             @retrying_scan_helper.before_testrun
-            update_scan_options
-
-            values = scan_config.values(ask: false)
-            values[:xcode_path] = File.expand_path("../..", FastlaneCore::Helper.xcode_path)
-            ScanHelper.print_scan_parameters(values)
-
             Scan::Runner.new.run
             @retrying_scan_helper.after_testrun
             true

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -98,11 +98,14 @@ module TestCenter
             FastlaneCore::UI.important('Disabling -quiet as failing tests cannot be found with it enabled.')
             xcargs.gsub!('-quiet', '')
           end
-          xcargs.gsub!(/-parallel-testing-enabled(=|\s+)(YES|NO)/, '')
+          if FastlaneCore::Helper.xcode_at_least?(10)
+            xcargs.gsub!(/-parallel-testing-enabled(=|\s+)(YES|NO)/, '')
+            xcargs << " -parallel-testing-enabled NO "
+          end
           retrying_scan_options = @reportnamer.scan_options.merge(
             {
               output_directory: output_directory,
-              xcargs: "#{xcargs} -parallel-testing-enabled NO "
+              xcargs: xcargs
             }
           )
           if @reportnamer.includes_xcresult?

--- a/spec/multi_scan_manager/retrying_scan_helper_spec.rb
+++ b/spec/multi_scan_manager/retrying_scan_helper_spec.rb
@@ -6,6 +6,12 @@ module TestCenter::Helper::MultiScanManager
       allow(File).to receive(:open).and_call_original
       allow(Scan).to receive(:config).and_return(derived_data_path: '')
       allow(Scan).to receive(:config=)
+      @mock_scan_runner = OpenStruct.new
+      allow(Scan::Runner).to receive(:new).and_return(@mock_scan_runner)
+      @mock_scan_config = FastlaneCore::Configuration.new(Fastlane::Actions::ScanAction.available_options, { derived_data_path: ''} )
+      allow_any_instance_of(RetryingScanHelper).to receive(:scan_config).and_return(@mock_scan_config)
+      @mock_scan_cache = { destination: ["platform=iOS Simulator,id=HungryHippo"] }
+      allow_any_instance_of(RetryingScanHelper).to receive(:scan_cache).and_return(@mock_scan_cache)
       allow(FastlaneCore::UI).to receive(:message).and_call_original
       allow(FileUtils).to receive(:rm_rf).and_call_original
       @xcpretty_json_file_output = ENV['XCPRETTY_JSON_FILE_OUTPUT']
@@ -825,6 +831,68 @@ module TestCenter::Helper::MultiScanManager
           xcargs: "-parallel-testing-enabled=YES"
         )
         helper.update_only_testing
+      end
+    end
+
+    describe '#update_scan_options' do
+      it 'removes the :device and :devices options from the Scan config' do
+        retrying_scan_helper = RetryingScanHelper.new(
+          {
+            derived_data_path: './path/to/derived_data_path'
+          }
+        )
+        expect(retrying_scan_helper).to receive(:prepare_scan_config)
+        retrying_scan_helper.prepare_scan_config
+      end
+
+      it 'updates Scan.devices when :scan_devices_override is set' do
+        Scan.devices = initial_scan_devices = [
+          OpenStruct.new(name: 'Alpha'),
+          OpenStruct.new(name: 'Beta')
+        ]
+
+        overridden_scan_devices = [
+          OpenStruct.new(name: 'Alpha'),
+          OpenStruct.new(name: 'Beta')
+        ]
+        retrying_scan_helper = RetryingScanHelper.new(
+          {
+            derived_data_path: './path/to/derived_data_path',
+            scan_devices_override: overridden_scan_devices
+          }
+        )
+        allow(retrying_scan_helper).to receive(:prepare_scan_config)
+
+        retrying_scan_helper.set_scan_config
+
+        expect(Scan.devices).to eq(overridden_scan_devices)
+      end
+    end
+
+    describe '#prepare_scan_config' do
+      it 'removes :device and :devices' do
+        retrying_scan_helper = RetryingScanHelper.new({})
+
+        @mock_scan_config[:device] = 'iPhone 91v'
+        @mock_scan_config[:devices] = ['iPhone 92w', 'iPhone 92x']
+
+        retrying_scan_helper.prepare_scan_config
+        expect(@mock_scan_config[:device]).to be_nil
+        expect(@mock_scan_config[:devices]).to be_nil
+      end
+
+      it 'clears out the Scan cache' do
+        retrying_scan_helper = RetryingScanHelper.new({})
+        retrying_scan_helper.prepare_scan_config
+        expect(@mock_scan_cache).to be_empty
+      end
+
+      it 'removes :result_bundle if ReportNamer includes "xcresult" output_type' do
+        allow(ReportNameHelper).to receive(:includes_xcresult?).and_return(true)
+        retrying_scan_helper = RetryingScanHelper.new({})
+        @mock_scan_config[:result_bundle] = true
+        retrying_scan_helper.prepare_scan_config
+        expect(@mock_scan_config[:result_bundle]).to be_falsey
       end
     end
   end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This fixes the issue #305, where Xcode 9 and prior versions do not understand the
-parallel-testing-enabled flag and will error out instead of running the users tests.

### Description
<!-- Describe your changes in detail -->

Check the version of Xcode before adding the problematic flag.


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
