### PR TITLE
issue-310 Remove :testplan option from Scan config

### DIFF
--- a/AtomicBoy/AtomicBoy.xcodeproj/xcshareddata/xcschemes/SuperAtomicBoy.xcscheme
+++ b/AtomicBoy/AtomicBoy.xcodeproj/xcshareddata/xcschemes/SuperAtomicBoy.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1150"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "26DB0F4E1FA12D4B0023C31D"
+               BuildableName = "AtomicBoy.app"
+               BlueprintName = "AtomicBoy"
+               ReferencedContainer = "container:AtomicBoy.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:AtomicBoy_2.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "26DB0F6D1FA12D4B0023C31D"
+               BuildableName = "AtomicBoyTests.xctest"
+               BlueprintName = "AtomicBoyTests"
+               ReferencedContainer = "container:AtomicBoy.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "26DB0F781FA12D4B0023C31D"
+               BuildableName = "AtomicBoyUITests.xctest"
+               BlueprintName = "AtomicBoyUITests"
+               ReferencedContainer = "container:AtomicBoy.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "26DB0F4E1FA12D4B0023C31D"
+            BuildableName = "AtomicBoy.app"
+            BlueprintName = "AtomicBoy"
+            ReferencedContainer = "container:AtomicBoy.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "26DB0F4E1FA12D4B0023C31D"
+            BuildableName = "AtomicBoy.app"
+            BlueprintName = "AtomicBoy"
+            ReferencedContainer = "container:AtomicBoy.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AtomicBoy/AtomicBoy.xcodeproj/xcuserdata/lyndsey.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/AtomicBoy/AtomicBoy.xcodeproj/xcuserdata/lyndsey.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -24,6 +24,11 @@
 			<key>orderHint</key>
 			<integer>2</integer>
 		</dict>
+		<key>SuperAtomicBoy.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>4</integer>
+		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>
 	<dict>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,3 +22,23 @@ action_integration_tests.each do |action_name, integration_tests|
     end
   end
 end
+
+lane :issue_310 do
+  test_options = test_options_from_testplan(
+    testplan: 'MyProject-TESTS.xctestplan'
+  )
+  only_testing = test_options[:only_testing]
+  only_testing.each do |test_identifier|
+    puts test_identifier
+  end
+end
+
+lane :testing do
+  multi_scan(
+    workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
+    scheme: 'SuperAtomicBoy',
+    fail_build: false,
+    try_count: 2,
+    testplan: 'AtomicBoy_2'
+  )
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,10 +35,10 @@ end
 
 lane :testing do
   multi_scan(
-    workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
-    scheme: 'SuperAtomicBoy',
+    project: File.absolute_path('../FastlaneTestPlan/FastlaneTestPlan.xcodeproj'),
+    scheme: 'FastlaneTestPlan',
     fail_build: false,
     try_count: 2,
-    testplan: 'AtomicBoy_2'
+    testplan: 'FastlaneTestPlan/FastlaneTestPlan'
   )
 end

--- a/lib/fastlane/plugin/test_center/actions/multi_scan.rb
+++ b/lib/fastlane/plugin/test_center/actions/multi_scan.rb
@@ -629,6 +629,16 @@ module Fastlane
             try_count: 2,
             batch_count: 2
           )
+          ",
+          "
+          UI.header('Basic test with testplan')
+          multi_scan(
+            workspace: File.absolute_path('../AtomicBoy/AtomicBoy.xcworkspace'),
+            scheme: 'SuperAtomicBoy',
+            fail_build: false,
+            try_count: 2,
+            testplan: 'AtomicBoy_2'
+          )
           "
         ]
       end

--- a/lib/fastlane/plugin/test_center/actions/test_options_from_testplan.rb
+++ b/lib/fastlane/plugin/test_center/actions/test_options_from_testplan.rb
@@ -8,6 +8,8 @@ module Fastlane
 
         testplan = JSON.load(File.open(testplan_path))
         only_testing = []
+        skip_testing = []
+
         UI.verbose("Examining testplan JSON: #{testplan}")
         testplan['testTargets'].each do |test_target|
           testable = test_target.dig('target', 'name')
@@ -18,6 +20,13 @@ module Fastlane
               UI.verbose("    Found test: '#{selected_test}'")
               only_testing << "#{testable}/#{selected_test.sub('\/', '/')}"
             end
+          elsif test_target.key?('skippedTests')
+            UI.verbose(" . Found skippedTests")
+            test_identifiers = test_target['skippedTests'].each do |skipped_test|
+              skipped_test.delete!('()')
+              UI.verbose(" .   Found test: '#{skipped_test}'")
+              skip_testing << "#{testable}/#{skipped_test.sub('\/', '/')}"
+            end
           else
             UI.verbose("  No selected tests, using testable '#{testable}'")
             only_testing << testable
@@ -25,7 +34,8 @@ module Fastlane
         end
         {
           code_coverage: testplan.dig('defaultOptions', 'codeCoverage'),
-          only_testing: only_testing
+          only_testing: only_testing,
+          skip_testing: skip_testing
         }
       end
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan.rb
@@ -29,6 +29,10 @@ module TestCenter
             ENV.delete('SCAN_RESULT_BUNDLE')
           end
           scan_config._values.delete(:skip_testing)
+          scan_config._values.delete(:testplan)
+          if scan_config.config_file_options
+            scan_config.config_file_options.reject! { |k, v| %i[skip_testing testplan device devices].include?(k) }
+          end
           scan_cache.clear
         end
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -68,6 +68,7 @@ module TestCenter
           @options.reject! { |key| %i[testplan].include?(key) }
           @batch_count = @test_collector.batches.size
           tests = @test_collector.batches.flatten
+          FastlaneCore::UI.verbose("Test Collector reports #{@batch_count}")
           if tests.size < @options[:parallel_testrun_count].to_i
             FastlaneCore::UI.important(":parallel_testrun_count greater than the number of tests (#{tests.size}). Reducing to that number.")
             @options[:parallel_testrun_count] = tests.size
@@ -235,7 +236,7 @@ module TestCenter
           remaining_test_batches = @test_collector.batches.clone
           remaining_test_batches.each_with_index do |test_batch, current_batch_index|
             worker = pool.wait_for_worker
-            FastlaneCore::UI.message("Starting test run #{current_batch_index + 1}")
+            FastlaneCore::UI.message("Starting test run batch #{current_batch_index + 1} with #{test_batch.size} tests")
             worker.run(scan_options_for_worker(test_batch, current_batch_index))
           end
           pool.wait_for_all_workers

--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -61,7 +61,9 @@ module TestCenter
         testable_tests_hash = Hash.new { |h, k| h[k] = [] }
         only_testing = derive_only_testing(options)
         if only_testing
+          FastlaneCore::UI.verbose("testable_tests_hash_from_options: only_testing before 'expansion': #{only_testing}\n")
           expand_test_identifiers(only_testing)
+          FastlaneCore::UI.verbose("\ntestable_tests_hash_from_options: only_testing after 'expansion' : #{only_testing}")
           only_testing.each do |test_identifier|
             testable = test_identifier.split('/')[0]
             testable_tests_hash[testable] << test_identifier

--- a/lib/fastlane/plugin/test_center/helper/test_collector.rb
+++ b/lib/fastlane/plugin/test_center/helper/test_collector.rb
@@ -188,6 +188,8 @@ module TestCenter
             }
           )
           @test_options = Fastlane::Actions::TestOptionsFromTestplanAction.run(config)
+          @test_options.delete(:only_testing) if @test_options[:only_testing].empty?
+          @test_options.delete(:skip_testing) if @test_options[:skip_testing].empty?
         end
         @test_options
       end


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

A user found in #310, that the `:testplan` option can be passed down to `scan`; my theory is that they are passing it via a `Scanfile`. 

### Description
<!-- Describe your changes in detail -->

Remove unwanted options from the `Scan` file configuration variable before calling `scan`.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
