### PR TITLE
issue-327 support skipped test identifiers in xcresult

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/tests_from_xcresult.rb
+++ b/lib/fastlane/plugin/test_center/actions/tests_from_xcresult.rb
@@ -33,6 +33,7 @@ module Fastlane
         testable_summaries = all_summaries.map(&:testable_summaries).flatten
         failed = []
         passing = []
+	 skipped = []
         failure_details = {}
         testable_summaries.map do |testable_summary|
           target_name = testable_summary.target_name
@@ -40,6 +41,8 @@ module Fastlane
           all_tests.each do |t|
             if t.test_status == 'Success'
               passing << "#{target_name}/#{t.identifier.sub('()', '')}"
+            elsif t.test_status == 'Skipped'
+              skipped << "#{target_name}/#{t.identifier.sub('()', '')}"
             else
               test_identifier = "#{target_name}/#{t.identifier.sub('()', '')}"
               failed << test_identifier
@@ -55,6 +58,7 @@ module Fastlane
         {
           failed: failed.uniq,
           passing: passing.uniq,
+	   skipped: skipped.uniq,
           failure_details: failure_details
         }
       end
@@ -64,7 +68,7 @@ module Fastlane
       #####################################################
 
       def self.description
-        "☑️ Retrieves the failing and passing tests as reportedn an xcresult bundle"
+        "☑️ Retrieves the failing, passing, and skipped tests as reported in a xcresult bundle"
       end
 
 
@@ -85,7 +89,8 @@ module Fastlane
       def self.return_value
         "A Hash with information about the test results:\r\n" \
         "failed: an Array of the failed test identifiers\r\n" \
-        "passing: an Array of the passing test identifiers\r\n"
+        "passing: an Array of the passing test identifiers\r\n" \
+	 "skipped: an Array of the skipped test identifiers\r\n"
       end
 
       def self.authors


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

This adds new functionality requested by a user in #327 to gather "skipped" tests from an xcresult file.

### Description
<!-- Describe your changes in detail -->

Add skipped tests to the information reported by the `tests_from_xcresult` action.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
