### PR TITLE
issue-327 downcase xcresult paths for comparison

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
@@ -161,7 +161,7 @@ module TestCenter
             )
             CollateXcresultsAction.run(config)
             FileUtils.rm_rf(test_xcresult_bundlepaths - [collated_xcresult_bundlepath])
-          elsif test_xcresult_bundlepaths.size == 1 && File.realdirpath(test_xcresult_bundlepaths.first) != File.realdirpath(collated_xcresult_bundlepath)
+          elsif test_xcresult_bundlepaths.size == 1 && File.realdirpath(test_xcresult_bundlepaths.first.downcase) != File.realdirpath(collated_xcresult_bundlepath.downcase)
             FastlaneCore::UI.verbose("Copying xcresult bundle from #{test_xcresult_bundlepaths.first} to #{collated_xcresult_bundlepath}")
             FileUtils.mkdir_p(File.dirname(collated_xcresult_bundlepath))
             FileUtils.mv(test_xcresult_bundlepaths.first, collated_xcresult_bundlepath)


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes #327 by normalizing the path names for potential source and destination to lowercase to ensure that we're discounting case differences in macOS.

### Description
<!-- Describe your changes in detail -->

Use the `:downcase` method on both the source and destination path before comparing in the collate xcresult method.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
