### PR TITLE
issue-327 downcase xcresult paths for comparison

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/collate_xcresults.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_xcresults.rb
@@ -36,6 +36,8 @@ module Fastlane
         end
 
         UI.message("Finished collating xcresults to '#{params[:collated_xcresult]}'")
+        UI.verbose("  final xcresults: #{other_action.tests_from_xcresult(xcresult: params[:collated_xcresult])}")
+
         commands_run
       end
 

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
@@ -15,6 +15,7 @@ module TestCenter
         CollateXcresultsAction = Fastlane::Actions::CollateXcresultsAction
 
         def initialize(params)
+          FastlaneCore::UI.verbose("ReportCollator.initialize with ':source_reports_directory_glob' of \"#{params[:source_reports_directory_glob]}\"")
           @source_reports_directory_glob = params[:source_reports_directory_glob]
           @output_directory = params[:output_directory]
           @reportnamer = params[:reportnamer]
@@ -143,7 +144,7 @@ module TestCenter
           end
         end
 
-        def collate_xcresult_bundles 
+        def collate_xcresult_bundles
           return unless @reportnamer.includes_xcresult?
 
           test_xcresult_bundlepaths = sort_globbed_files("#{@source_reports_directory_glob}/#{@reportnamer.xcresult_fileglob}")

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/report_collator.rb
@@ -161,7 +161,7 @@ module TestCenter
             )
             CollateXcresultsAction.run(config)
             FileUtils.rm_rf(test_xcresult_bundlepaths - [collated_xcresult_bundlepath])
-          elsif test_xcresult_bundlepaths.size == 1 && File.realdirpath(test_xcresult_bundlepaths.first) != File.realdirpath(collated_xcresult_bundlepath)
+          elsif test_xcresult_bundlepaths.size == 1 && File.realdirpath(test_xcresult_bundlepaths.first.downcase) != File.realdirpath(collated_xcresult_bundlepath.downcase)
             FastlaneCore::UI.verbose("Copying xcresult bundle from #{test_xcresult_bundlepaths.first} to #{collated_xcresult_bundlepath}")
             FileUtils.mkdir_p(File.dirname(collated_xcresult_bundlepath))
             FileUtils.mv(test_xcresult_bundlepaths.first, collated_xcresult_bundlepath)

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -9,6 +9,7 @@ module TestCenter
           raise ArgumentError, 'Do not use the :device or :devices option. Instead use the :destination option.' if (options.key?(:device) or options.key?(:devices))
 
           @options = options
+          FastlaneCore::UI.verbose("RetryingScanHelper.initialize with ':output' as \"#{@options[:output_directory]}\"")
           @testrun_count = 0
           @xcpretty_json_file_output = ENV['XCPRETTY_JSON_FILE_OUTPUT']
           @reportnamer = ReportNameHelper.new(
@@ -54,7 +55,7 @@ module TestCenter
               Scan.devices = @options[:scan_devices_override]
             end
           end
- 
+
           values = scan_config.values(ask: false)
           values[:xcode_path] = File.expand_path("../..", FastlaneCore::Helper.xcode_path)
           ScanHelper.print_scan_parameters(values)
@@ -447,7 +448,7 @@ module TestCenter
           return unless @options[:result_bundle]
 
           result_extension = FastlaneCore::Helper.xcode_at_least?('11') ? '.xcresult' : '.test_result'
-          
+
           glob_pattern = "#{output_directory}/*#{result_extension}"
           preexisting_test_result_bundles = Dir.glob(glob_pattern)
           unnumbered_test_result_bundles = preexisting_test_result_bundles.reject do |test_result|

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -103,7 +103,7 @@ module TestCenter
           end
 
           unless test_results.all? || @options[:try_count] < 1
-            test_results.clear 
+            test_results.clear
             setup_testcollector
             setup_run_tests_for_each_device do |device_name|
               FastlaneCore::UI.message("Testing batches for device '#{device_name}'") if device_name
@@ -114,7 +114,7 @@ module TestCenter
         end
 
         def setup_run_tests_for_each_device
-          original_output_directory = @options.fetch(:output_directory, 'test_results') 
+          original_output_directory = @options.fetch(:output_directory, 'test_results')
           unless @options[:platform] == :ios_simulator
             yield
             return
@@ -359,12 +359,12 @@ module TestCenter
 
           absolute_output_directory = File.absolute_path(output_directory)
           source_reports_directory_glob = "#{absolute_output_directory}/*"
-
+          FastlaneCore::UI.verbose("MultiScanManager::Runner sending 'source_reports_directory_glob' of \"#{source_reports_directory_glob}\"")
           TestCenter::Helper::MultiScanManager::ReportCollator.new(
             source_reports_directory_glob: source_reports_directory_glob,
             output_directory: absolute_output_directory,
             reportnamer: report_name_helper
-          ).collate_junit_reports 
+          ).collate_junit_reports
         end
 
         def collate_batched_reports_for_testable(testable)

--- a/spec/collate_xcresults_spec.rb
+++ b/spec/collate_xcresults_spec.rb
@@ -19,6 +19,9 @@ module Fastlane::Actions
     before(:each) do
      allow(File).to receive(:exist?).and_call_original
      allow(Dir).to receive(:exist?).with(%r{path/to/fake(1|2|3)?\.xcresult}).and_return(true)
+     mock_tests_from_xcresult = OpenStruct.new
+     allow(mock_tests_from_xcresult).to receive(:tests_from_xcresult)
+     allow(Fastlane::Actions::CollateXcresultsAction).to receive(:other_action).and_return(mock_tests_from_xcresult)
     end
 
     it "returns nil when Xcode 10 or earlier" do


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Fixes #328 by normalizing the path names for potential source and destination to lowercase to ensure that we're discounting case differences in macOS.

### Description
<!-- Describe your changes in detail -->

Use the `:downcase` method on both the source and destination path before comparing in the collate xcresult method.


<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
