### PR TITLE
Detect projects before running multi_scan

### DIFF
--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/runner.rb
@@ -12,6 +12,7 @@ module TestCenter
         attr_reader :retry_total_count
 
         def initialize(multi_scan_options)
+          FastlaneCore::Project.detect_projects(multi_scan_options)
           @options = multi_scan_options.merge(
             clean: false,
             disable_concurrent_testing: true


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->
Fixes https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/issues/362

### Description
<!-- Describe your changes in detail -->
Run detect_projects on the options before starting multi_scan

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
