### PR TITLE
Remove trainer dep update fastlane

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-        - 2.4.x
         - 2.5.x
     name: Run Tests with Ruby ${{ matrix.ruby }}
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -316,7 +316,7 @@ Layout/SpaceAroundOperators:
     - '**/spec/actions_specs/xcodebuild_spec.rb'
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Include:
     - '**/fastlane/Fastfile'
   Exclude:

--- a/fastlane-plugin-test_center.gemspec
+++ b/fastlane-plugin-test_center.gemspec
@@ -22,14 +22,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'json'
   spec.add_dependency 'plist'
-  spec.add_dependency 'trainer'
   spec.add_dependency 'xcodeproj'
   spec.add_dependency 'xctest_list', '>= 1.2.1'
   spec.add_dependency 'colorize'
 
   spec.add_development_dependency 'cocoapods'
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'fastlane', '>= 2.108.0'
+  spec.add_development_dependency 'fastlane', '>= 2.201.0'
   spec.add_development_dependency 'markdown-tables'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [x] I've read the [Contribution Guidelines][contributing doc]
- [x] I've updated the documentation if necessary.

### Motivation and Context
Fixes https://github.com/fastlane/fastlane/issues/19834
Fixes https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/issues/374

Addresses the stale PR: https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/pull/375 with suggestions from comments

### Description
_fastlane_ 2.201.0 now has `trainer` built into it. `trainer` was a dependency of `test_center` but no longer needs to be. `trainer` has been removed and `fastlane` is now required to be `>= 2.201.0`.

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
