### PR TITLE
[WIP] pass result_bundle_path instead of xcargs to scan

### DIFF
--- a/lib/fastlane/plugin/test_center/actions/collate_xcresults.rb
+++ b/lib/fastlane/plugin/test_center/actions/collate_xcresults.rb
@@ -36,7 +36,6 @@ module Fastlane
         end
 
         UI.message("Finished collating xcresults to '#{params[:collated_xcresult]}'")
-        UI.verbose("  final xcresults: #{other_action.tests_from_xcresult(xcresult: params[:collated_xcresult])}")
 
         commands_run
       end

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -179,7 +179,7 @@ module TestCenter
             }
           )
           if @reportnamer.includes_xcresult?
-            retrying_scan_options[:xcargs] += "-resultBundlePath '#{File.join(output_directory, @reportnamer.xcresult_last_bundlename)}' "
+            retrying_scan_options[:result_bundle_path] = File.join(output_directory, @reportnamer.xcresult_last_bundlename)
           end
 
           @options.select { |k,v| valid_scan_keys.include?(k) }

--- a/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
+++ b/lib/fastlane/plugin/test_center/helper/multi_scan_manager/retrying_scan_helper.rb
@@ -181,6 +181,7 @@ module TestCenter
           if @reportnamer.includes_xcresult?
             retrying_scan_options[:result_bundle_path] = File.join(output_directory, @reportnamer.xcresult_last_bundlename)
           end
+          retrying_scan_options[:fail_build] = true
 
           @options.select { |k,v| valid_scan_keys.include?(k) }
             .merge(retrying_scan_options)


### PR DESCRIPTION
Depends on https://github.com/fastlane/fastlane/pull/20742

<!-- Thanks for contributing to _test_center_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've run `bundle exec rake` from the root directory to see all new and existing tests pass
- [ ] I've read the [Contribution Guidelines][contributing doc]
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Please describe in detail how you tested your changes. -->

Resolves #384 

### Description
<!-- Describe your changes in detail -->

Updating from fastlane 2.182.0 and test center plugin 3.15.3, initially everything was always retried because scan raised build error due to xcresult not found in dervied data

result_bundle_path -> see attached fatlane PR and issue

setting fail_build -> test failure exception is only thrown if this is set to true, so tests were not retried without this

removing log -> other_action was always nil there for me

<!-- Links -->
[contributing doc]: ../docs/CONTRIBUTING.md
